### PR TITLE
fix path of SFSCON logo in container

### DIFF
--- a/data/c3nav.cfg
+++ b/data/c3nav.cfg
@@ -7,7 +7,7 @@ svg_renderer=rsvg
 editor=False
 user_registration=false
 initial_level=2
-header_logo=data/logo/sfscon.svg
+header_logo=/data/logo/sfscon.svg
 imprint_link=https://www.sfscon.it/impressum/
 
 [theme]


### PR DESCRIPTION
@sseppi 
The path in the container online differ from the one on my local installation, hence I had to fix the path.

@clezag 
Please review also https://github.com/noi-techpark/sfscon-maps/issues/7 which is related.


**NB: Both fixes were already tested and applied online, hence you see the logo working, but this PR persists the fix**