### PR TITLE
add manual database dump from testing perfomed to preserve changes

### DIFF
--- a/db/dump.sql
+++ b/db/dump.sql
@@ -511,6 +511,7 @@ DROP TABLE IF EXISTS public.auth_group_permissions;
 DROP TABLE IF EXISTS public.auth_group;
 DROP TABLE IF EXISTS public.api_secret;
 DROP TABLE IF EXISTS public.api_logintoken;
+
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
@@ -3014,207 +3015,207 @@ COPY public.django_content_type (id, app_label, model) FROM stdin;
 --
 
 COPY public.django_migrations (id, app, name, applied) FROM stdin;
-1	contenttypes	0001_initial	2024-08-27 11:57:42.723509+02
-2	auth	0001_initial	2024-08-27 11:57:42.885499+02
-3	admin	0001_initial	2024-08-27 11:57:42.927278+02
-4	admin	0002_logentry_remove_auto_add	2024-08-27 11:57:42.939178+02
-5	admin	0003_logentry_add_action_flag_choices	2024-08-27 11:57:42.951548+02
-6	mapdata	0001_squashed_refactor_2017	2024-08-27 11:57:45.7437+02
-7	mapdata	0002_locationredirect	2024-08-27 11:57:45.754826+02
-8	mapdata	0003_space_outside	2024-08-27 11:57:45.758164+02
-9	mapdata	0004_space_level_category_name	2024-08-27 11:57:45.761399+02
-10	mapdata	0005_auto_20170527_1556	2024-08-27 11:57:45.764762+02
-11	mapdata	0006_remove_section_name	2024-08-27 11:57:45.768032+02
-12	mapdata	0007_assign_hole_space	2024-08-27 11:57:45.771276+02
-13	mapdata	0008_auto_20170608_1317	2024-08-27 11:57:45.774513+02
-14	mapdata	0009_column	2024-08-27 11:57:45.777869+02
-15	mapdata	0010_on_top_of	2024-08-27 11:57:45.782128+02
-16	mapdata	0011_outside_only_outside	2024-08-27 11:57:45.78627+02
-17	mapdata	0012_rename_section_to_level	2024-08-27 11:57:45.79037+02
-18	mapdata	0013_auto_20170618_1934	2024-08-27 11:57:45.794617+02
-19	mapdata	0014_mapupdate	2024-08-27 11:57:45.798823+02
-20	mapdata	0015_auto_20170706_1334	2024-08-27 11:57:45.803036+02
-21	mapdata	0016_remove_source_image	2024-08-27 11:57:45.807201+02
-22	mapdata	0017_point_to_poi	2024-08-27 11:57:45.811312+02
-23	mapdata	0018_auto_20170708_1752	2024-08-27 11:57:45.814525+02
-24	mapdata	0019_location_group_category	2024-08-27 11:57:45.817789+02
-25	mapdata	0020_auto_20170710_1848	2024-08-27 11:57:45.821055+02
-26	mapdata	0021_auto_20170710_1916	2024-08-27 11:57:45.824314+02
-27	mapdata	0022_remove_space_category	2024-08-27 11:57:45.827552+02
-28	mapdata	0023_auto_20170711_1741	2024-08-27 11:57:45.830785+02
-29	mapdata	0024_remove_compiled_room_area	2024-08-27 11:57:45.834138+02
-30	mapdata	0025_remove_area_stuffed	2024-08-27 11:57:45.838237+02
-31	mapdata	0026_remove_specificlocation_color	2024-08-27 11:57:45.84236+02
-32	mapdata	0027_access_restriction	2024-08-27 11:57:45.84653+02
-33	mapdata	0028_door_access_restriction	2024-08-27 11:57:45.850662+02
-34	mapdata	0029_auto_20170714_1519	2024-08-27 11:57:45.854964+02
-35	mapdata	0030_altitudes	2024-08-27 11:57:45.859161+02
-36	mapdata	0031_auto_20170805_1647	2024-08-27 11:57:45.863259+02
-37	mapdata	0032_remove_graphnode_space_transfer	2024-08-27 11:57:45.86736+02
-38	mapdata	0033_auto_20170807_1423	2024-08-27 11:57:45.870573+02
-39	mapdata	0034_auto_20170807_1523	2024-08-27 11:57:45.873837+02
-40	mapdata	0035_auto_20170916_1216	2024-08-27 11:57:45.877044+02
-41	mapdata	0036_geometry_bounds	2024-08-27 11:57:45.880205+02
-42	mapdata	0037_level_geoms_cache	2024-08-27 11:57:45.883408+02
-43	mapdata	0038_level_render_data	2024-08-27 11:57:45.886609+02
-44	mapdata	0039_auto_20171024_2011	2024-08-27 11:57:45.889873+02
-45	mapdata	0040_access_permissions	2024-08-27 11:57:45.893103+02
-46	mapdata	0041_level_short_label	2024-08-27 11:57:45.897411+02
-47	mapdata	0042_auto_20171031_1507	2024-08-27 11:57:45.901581+02
-48	mapdata	0043_auto_20171110_1451	2024-08-27 11:57:45.90589+02
-49	mapdata	0044_mapupdate_processed	2024-08-27 11:57:45.910066+02
-50	mapdata	0045_level_door_height	2024-08-27 11:57:45.914284+02
-51	mapdata	0046_remove_level_render_data	2024-08-27 11:57:45.918428+02
-52	mapdata	0047_remove_mapupdate_changed_geometries	2024-08-27 11:57:45.922651+02
-53	mapdata	0048_ramp	2024-08-27 11:57:45.926913+02
-54	mapdata	0049_altitude_area_ramp	2024-08-27 11:57:45.930145+02
-55	mapdata	0050_remove_geometry_bounds	2024-08-27 11:57:45.93336+02
-56	mapdata	0051_auto_20171125_1241	2024-08-27 11:57:45.936629+02
-57	mapdata	0052_auto_20171125_1335	2024-08-27 11:57:45.939862+02
-58	mapdata	0053_i18nfield	2024-08-27 11:57:45.943067+02
-59	mapdata	0054_title_plural	2024-08-27 11:57:45.94637+02
-60	mapdata	0055_grant_access_permissions	2024-08-27 11:57:45.94959+02
-61	mapdata	0056_accesspermissiontoken	2024-08-27 11:57:45.952916+02
-62	mapdata	0057_waytype_fields	2024-08-27 11:57:45.957066+02
-63	mapdata	0058_wifimeasurement	2024-08-27 11:57:45.961135+02
-64	mapdata	0059_multiple_accesspermissions	2024-08-27 11:57:45.965397+02
-65	mapdata	0060_access_permission_id	2024-08-27 11:57:45.969543+02
-66	mapdata	0061_space_based_route_descriptions	2024-08-27 11:57:45.973869+02
-67	mapdata	0062_typos	2024-08-27 11:57:45.978108+02
-68	mapdata	0063_descriptions_unique_together	2024-08-27 11:57:45.982313+02
-69	mapdata	0064_access_permission_unique_key	2024-08-27 11:57:45.986325+02
-70	mapdata	0065_access_restriction_group	2024-08-27 11:57:45.989467+02
-71	mapdata	0066_area_slow_down_factor	2024-08-27 11:57:45.992632+02
-72	mapdata	0067_space_enter_description	2024-08-27 11:57:45.995857+02
-73	mapdata	0068_waytype_level_change_description	2024-08-27 11:57:45.998946+02
-74	mapdata	0069_mapupdate_geometries_changed	2024-08-27 11:57:46.002113+02
-75	mapdata	0070_auto_20180918_1736	2024-08-27 11:57:46.005299+02
-76	mapdata	0071_space_base_mapdata_accessible	2024-08-27 11:57:46.008532+02
-77	mapdata	0002_fix_broken_spaces	2024-08-27 11:57:46.063211+02
-78	mapdata	0003_column_access_restriction	2024-08-27 11:57:46.126575+02
-79	mapdata	0004_mapupdate_types	2024-08-27 11:57:46.143054+02
-80	mapdata	0005_geometry_import_tag	2024-08-27 11:57:46.575212+02
-81	mapdata	0006_location_icon	2024-08-27 11:57:46.733351+02
-82	mapdata	0007_location_group_help_text	2024-08-27 11:57:46.897828+02
-83	mapdata	0008_validate_slug	2024-08-27 11:57:46.920409+02
-84	mapdata	0072_make_wifi_measurement_author_nullable	2024-08-27 11:57:46.997022+02
-85	mapdata	0073_locationgroup_hierarchy	2024-08-27 11:57:47.034252+02
-86	mapdata	0074_show_labels	2024-08-27 11:57:47.20163+02
-87	mapdata	0075_label_settings	2024-08-27 11:57:47.806179+02
-88	mapdata	0076_obstacle_color	2024-08-27 11:57:48.251462+02
-89	mapdata	0077_obstacle_altitude	2024-08-27 11:57:48.319484+02
-90	mapdata	0078_reports	2024-08-27 11:57:48.733881+02
-91	mapdata	0079_auto_20191224_1858	2024-08-27 11:57:48.879595+02
-92	mapdata	0080_auto_20191224_2203	2024-08-27 11:57:48.942036+02
-93	mapdata	0081_auto_20191225_1015	2024-08-27 11:57:49.233043+02
-94	mapdata	0082_dynamiclocation_position	2024-08-27 11:57:49.454565+02
-95	mapdata	0083_auto_20191227_1642	2024-08-27 11:57:49.53827+02
-96	mapdata	0084_position_timeout	2024-08-27 11:57:49.562811+02
-97	mapdata	0085_locationgroupcategory_allow_dynamic_locations	2024-08-27 11:57:49.581141+02
-98	mapdata	0086_django_4_0	2024-08-27 11:57:53.433557+02
-99	contenttypes	0002_remove_content_type_name	2024-08-27 11:57:53.5103+02
-100	auth	0002_alter_permission_name_max_length	2024-08-27 11:57:53.575171+02
-101	auth	0003_alter_user_email_max_length	2024-08-27 11:57:53.599379+02
-102	auth	0004_alter_user_username_opts	2024-08-27 11:57:53.623728+02
-103	auth	0005_alter_user_last_login_null	2024-08-27 11:57:53.647635+02
-104	auth	0006_require_contenttypes_0002	2024-08-27 11:57:53.651058+02
-105	auth	0007_alter_validators_add_error_messages	2024-08-27 11:57:53.672943+02
-106	auth	0008_alter_user_username_max_length	2024-08-27 11:57:53.703935+02
-107	control	0001_initial	2024-08-27 11:57:53.777867+02
-108	control	0002_userpermissions_access_all	2024-08-27 11:57:53.802912+02
-109	control	0003_auto_20171210_1452	2024-08-27 11:57:53.827703+02
-110	control	0004_more_user_permissions	2024-08-27 11:57:53.893158+02
-111	control	0005_editor_mapdata_permissions	2024-08-27 11:57:53.942208+02
-112	control	0006_user_space_access	2024-08-27 11:57:54.104337+02
-113	control	0007_userpermissions_manage_map_updates	2024-08-27 11:57:54.242443+02
-114	control	0008_userpermissions_reports	2024-08-27 11:57:54.36221+02
-115	control	0009_django_4_0	2024-08-27 11:57:54.607086+02
-116	control	0010_userpermissions_mesh_control	2024-08-27 11:57:54.658528+02
-117	api	0001_initial	2024-08-27 11:57:54.737125+02
-118	api	0002_django_4_0	2024-08-27 11:57:54.802191+02
-119	api	0003_rename_token_logintoken_secret	2024-08-27 11:57:55.102916+02
-120	api	0004_alter_secret_name	2024-08-27 11:57:55.132302+02
-121	auth	0009_alter_user_last_name_max_length	2024-08-27 11:57:55.16147+02
-122	auth	0010_alter_group_name_max_length	2024-08-27 11:57:55.350028+02
-123	auth	0011_update_proxy_permissions	2024-08-27 11:57:55.41671+02
-124	auth	0012_alter_user_first_name_max_length	2024-08-27 11:57:55.444353+02
-125	control	0011_remove_userpermissions_api_secret	2024-08-27 11:57:55.492785+02
-126	control	0012_userpermissions_grant_unlimited_access	2024-08-27 11:57:55.541242+02
-127	control	0013_userpermissions_nonpublic_themes	2024-08-27 11:57:55.592623+02
-128	control	0014_userpermissions_sources_access	2024-08-27 11:57:55.644732+02
-129	editor	0001_initial	2024-08-27 11:57:56.597311+02
-130	editor	0002_auto_20170612_1615	2024-08-27 11:57:56.601125+02
-131	editor	0003_auto_20170618_1942	2024-08-27 11:57:56.604448+02
-132	editor	0004_auto_20170620_0934	2024-08-27 11:57:56.607744+02
-133	editor	0005_auto_20170627_0027	2024-08-27 11:57:56.610979+02
-134	editor	0006_auto_20170629_1222	2024-08-27 11:57:56.614322+02
-135	editor	0007_auto_20170629_1327	2024-08-27 11:57:56.618568+02
-136	editor	0008_auto_20170629_1450	2024-08-27 11:57:56.622841+02
-137	editor	0009_auto_20170701_1218	2024-08-27 11:57:56.627082+02
-138	editor	0010_auto_20170704_1431	2024-08-27 11:57:56.631272+02
-139	editor	0011_auto_20170704_1640	2024-08-27 11:57:56.635557+02
-140	editor	0012_remove_changeset_session_id	2024-08-27 11:57:56.63978+02
-141	editor	0013_remove_changesetupdate_session_user	2024-08-27 11:57:56.643985+02
-142	editor	0014_last_update_foreign_key	2024-08-27 11:57:56.64818+02
-143	editor	0015_changeset_last_state_update	2024-08-27 11:57:56.65161+02
-144	editor	0016_auto_20170705_1938	2024-08-27 11:57:56.655023+02
-145	editor	0017_changeset_map_update	2024-08-27 11:57:56.658389+02
-146	editor	0018_changeset_last_cleaned_with	2024-08-27 11:57:56.661636+02
-147	editor	0019_permissions	2024-08-27 11:57:56.664991+02
-148	editor	0020_remove_permissions	2024-08-27 11:57:56.668251+02
-149	editor	0021_auto_20180918_1736	2024-08-27 11:57:56.671549+02
-150	editor	0002_django_4_0	2024-08-27 11:57:57.034555+02
-151	editor	0003_changedobject_json_encoder	2024-08-27 11:57:57.054668+02
-152	mapdata	0087_rangingbeacon	2024-08-27 11:57:57.163656+02
-153	mapdata	0088_remove_position_api_secret	2024-08-27 11:57:57.195682+02
-154	mapdata	0089_groundaltitude	2024-08-27 11:57:57.485463+02
-155	mapdata	0090_alter_report_author	2024-08-27 11:57:57.558095+02
-156	mapdata	0091_area_main_point	2024-08-27 11:57:57.608702+02
-157	mapdata	0092_accesspermission_by_group	2024-08-27 11:57:57.94174+02
-158	mapdata	0093_public_accessrestriction	2024-08-27 11:57:57.997669+02
-159	mapdata	0094_hub_import_prepare	2024-08-27 11:57:58.272683+02
-160	mapdata	0095_import_block	2024-08-27 11:57:58.851733+02
-161	mapdata	0095_accesspermission_for_session	2024-08-27 11:57:59.045496+02
-162	mapdata	0096_merge_20231225_2216	2024-08-27 11:57:59.048283+02
-163	mapdata	0097_longer_import_tag	2024-08-27 11:57:59.686923+02
-164	mapdata	0098_report_import_tag	2024-08-27 11:57:59.740631+02
-165	mapdata	0099_theming	2024-08-27 11:58:00.180053+02
-166	mapdata	0100_obstaclegroup_color_data	2024-08-27 11:58:00.261418+02
-167	mapdata	0101_remove_obstacle_color	2024-08-27 11:58:00.343321+02
-168	mapdata	0102_rename_bssid_rangingbeacon_wifi_bssid_and_more	2024-08-27 11:58:00.744145+02
-169	mapdata	0103_report_flow_overhaul	2024-08-27 11:58:01.267908+02
-170	mapdata	0104_theme_color_css_grid_and_more	2024-08-27 11:58:01.451199+02
-171	mapdata	0105_alter_theme_color_background_and_more	2024-08-27 11:58:01.507173+02
-172	mapdata	0106_rename_wifi_to_beaconmeasurement	2024-08-27 11:58:01.778579+02
-173	mesh	0001_initial	2024-08-27 11:58:01.897982+02
-174	mesh	0002_alter_firmware_unique_together_meshnode_firmware_and_more	2024-08-27 11:58:01.941023+02
-175	mesh	0003_meshnode_name	2024-08-27 11:58:01.951991+02
-176	mesh	0004_relay_vs_src_node_and_remove_firmware	2024-08-27 11:58:02.211169+02
-177	mesh	0005_meshnode_last_signin	2024-08-27 11:58:02.220932+02
-178	mesh	0006_rename_route_meshnode_uplink	2024-08-27 11:58:02.244607+02
-179	mesh	0007_nodemessage_message_type_new	2024-08-27 11:58:02.370616+02
-180	mesh	0008_firmwarebuild_firmwarebuildboard_firmwareversion_and_more	2024-08-27 11:58:02.784016+02
-181	mesh	0009_meshuplink	2024-08-27 11:58:03.018144+02
-182	mesh	0010_otaupdate_otaupdaterecipient	2024-08-27 11:58:03.237301+02
-183	mesh	0011_meshnode_address_validate	2024-08-27 11:58:03.327313+02
-184	mesh	0012_otaupdaterecipient_status_and_more	2024-08-27 11:58:03.363442+02
-185	mesh	0013_meshnode_upstream_alter_nodemessage_message_type	2024-08-27 11:58:03.473797+02
-186	mesh	0014_remove_meshnode_name	2024-08-27 11:58:03.485254+02
-187	routing	0001_routeoptions	2024-08-27 11:58:03.590206+02
-188	routing	0002_django_4_0	2024-08-27 11:58:03.724786+02
-189	sessions	0001_initial	2024-08-27 11:58:03.753999+02
-190	site	0001_announcement	2024-08-27 11:58:03.773676+02
-191	site	0002_announcement_tweaks	2024-08-27 11:58:04.028622+02
-192	site	0003_siteupdate	2024-08-27 11:58:04.041775+02
-193	site	0004_siteupdate_tweaks	2024-08-27 11:58:04.048811+02
-194	site	0005_siteupdate_default_related_name	2024-08-27 11:58:04.055683+02
-195	site	0006_django_4_0	2024-08-27 11:58:04.145531+02
-196	mapdata	0001_squashed_2018	2024-08-27 11:58:04.152164+02
-197	editor	0001_squashed_2018	2024-08-27 11:58:04.15528+02
-198	mapdata	0107_altitudearea_multiple_points	2024-09-24 12:03:02.577602+02
-199	mapdata	0108_in_legend	2024-09-24 12:03:02.833749+02
-200	mapdata	0109_accesspermissionssogrant_accesspermission_sso_grant	2024-09-24 12:03:03.120676+02
-201	mapdata	0110_theme_icon_path_theme_leaflet_marker_config	2024-09-24 12:03:03.142018+02
+1	contenttypes	0001_initial	2024-08-27 09:57:42.723509+00
+2	auth	0001_initial	2024-08-27 09:57:42.885499+00
+3	admin	0001_initial	2024-08-27 09:57:42.927278+00
+4	admin	0002_logentry_remove_auto_add	2024-08-27 09:57:42.939178+00
+5	admin	0003_logentry_add_action_flag_choices	2024-08-27 09:57:42.951548+00
+6	mapdata	0001_squashed_refactor_2017	2024-08-27 09:57:45.7437+00
+7	mapdata	0002_locationredirect	2024-08-27 09:57:45.754826+00
+8	mapdata	0003_space_outside	2024-08-27 09:57:45.758164+00
+9	mapdata	0004_space_level_category_name	2024-08-27 09:57:45.761399+00
+10	mapdata	0005_auto_20170527_1556	2024-08-27 09:57:45.764762+00
+11	mapdata	0006_remove_section_name	2024-08-27 09:57:45.768032+00
+12	mapdata	0007_assign_hole_space	2024-08-27 09:57:45.771276+00
+13	mapdata	0008_auto_20170608_1317	2024-08-27 09:57:45.774513+00
+14	mapdata	0009_column	2024-08-27 09:57:45.777869+00
+15	mapdata	0010_on_top_of	2024-08-27 09:57:45.782128+00
+16	mapdata	0011_outside_only_outside	2024-08-27 09:57:45.78627+00
+17	mapdata	0012_rename_section_to_level	2024-08-27 09:57:45.79037+00
+18	mapdata	0013_auto_20170618_1934	2024-08-27 09:57:45.794617+00
+19	mapdata	0014_mapupdate	2024-08-27 09:57:45.798823+00
+20	mapdata	0015_auto_20170706_1334	2024-08-27 09:57:45.803036+00
+21	mapdata	0016_remove_source_image	2024-08-27 09:57:45.807201+00
+22	mapdata	0017_point_to_poi	2024-08-27 09:57:45.811312+00
+23	mapdata	0018_auto_20170708_1752	2024-08-27 09:57:45.814525+00
+24	mapdata	0019_location_group_category	2024-08-27 09:57:45.817789+00
+25	mapdata	0020_auto_20170710_1848	2024-08-27 09:57:45.821055+00
+26	mapdata	0021_auto_20170710_1916	2024-08-27 09:57:45.824314+00
+27	mapdata	0022_remove_space_category	2024-08-27 09:57:45.827552+00
+28	mapdata	0023_auto_20170711_1741	2024-08-27 09:57:45.830785+00
+29	mapdata	0024_remove_compiled_room_area	2024-08-27 09:57:45.834138+00
+30	mapdata	0025_remove_area_stuffed	2024-08-27 09:57:45.838237+00
+31	mapdata	0026_remove_specificlocation_color	2024-08-27 09:57:45.84236+00
+32	mapdata	0027_access_restriction	2024-08-27 09:57:45.84653+00
+33	mapdata	0028_door_access_restriction	2024-08-27 09:57:45.850662+00
+34	mapdata	0029_auto_20170714_1519	2024-08-27 09:57:45.854964+00
+35	mapdata	0030_altitudes	2024-08-27 09:57:45.859161+00
+36	mapdata	0031_auto_20170805_1647	2024-08-27 09:57:45.863259+00
+37	mapdata	0032_remove_graphnode_space_transfer	2024-08-27 09:57:45.86736+00
+38	mapdata	0033_auto_20170807_1423	2024-08-27 09:57:45.870573+00
+39	mapdata	0034_auto_20170807_1523	2024-08-27 09:57:45.873837+00
+40	mapdata	0035_auto_20170916_1216	2024-08-27 09:57:45.877044+00
+41	mapdata	0036_geometry_bounds	2024-08-27 09:57:45.880205+00
+42	mapdata	0037_level_geoms_cache	2024-08-27 09:57:45.883408+00
+43	mapdata	0038_level_render_data	2024-08-27 09:57:45.886609+00
+44	mapdata	0039_auto_20171024_2011	2024-08-27 09:57:45.889873+00
+45	mapdata	0040_access_permissions	2024-08-27 09:57:45.893103+00
+46	mapdata	0041_level_short_label	2024-08-27 09:57:45.897411+00
+47	mapdata	0042_auto_20171031_1507	2024-08-27 09:57:45.901581+00
+48	mapdata	0043_auto_20171110_1451	2024-08-27 09:57:45.90589+00
+49	mapdata	0044_mapupdate_processed	2024-08-27 09:57:45.910066+00
+50	mapdata	0045_level_door_height	2024-08-27 09:57:45.914284+00
+51	mapdata	0046_remove_level_render_data	2024-08-27 09:57:45.918428+00
+52	mapdata	0047_remove_mapupdate_changed_geometries	2024-08-27 09:57:45.922651+00
+53	mapdata	0048_ramp	2024-08-27 09:57:45.926913+00
+54	mapdata	0049_altitude_area_ramp	2024-08-27 09:57:45.930145+00
+55	mapdata	0050_remove_geometry_bounds	2024-08-27 09:57:45.93336+00
+56	mapdata	0051_auto_20171125_1241	2024-08-27 09:57:45.936629+00
+57	mapdata	0052_auto_20171125_1335	2024-08-27 09:57:45.939862+00
+58	mapdata	0053_i18nfield	2024-08-27 09:57:45.943067+00
+59	mapdata	0054_title_plural	2024-08-27 09:57:45.94637+00
+60	mapdata	0055_grant_access_permissions	2024-08-27 09:57:45.94959+00
+61	mapdata	0056_accesspermissiontoken	2024-08-27 09:57:45.952916+00
+62	mapdata	0057_waytype_fields	2024-08-27 09:57:45.957066+00
+63	mapdata	0058_wifimeasurement	2024-08-27 09:57:45.961135+00
+64	mapdata	0059_multiple_accesspermissions	2024-08-27 09:57:45.965397+00
+65	mapdata	0060_access_permission_id	2024-08-27 09:57:45.969543+00
+66	mapdata	0061_space_based_route_descriptions	2024-08-27 09:57:45.973869+00
+67	mapdata	0062_typos	2024-08-27 09:57:45.978108+00
+68	mapdata	0063_descriptions_unique_together	2024-08-27 09:57:45.982313+00
+69	mapdata	0064_access_permission_unique_key	2024-08-27 09:57:45.986325+00
+70	mapdata	0065_access_restriction_group	2024-08-27 09:57:45.989467+00
+71	mapdata	0066_area_slow_down_factor	2024-08-27 09:57:45.992632+00
+72	mapdata	0067_space_enter_description	2024-08-27 09:57:45.995857+00
+73	mapdata	0068_waytype_level_change_description	2024-08-27 09:57:45.998946+00
+74	mapdata	0069_mapupdate_geometries_changed	2024-08-27 09:57:46.002113+00
+75	mapdata	0070_auto_20180918_1736	2024-08-27 09:57:46.005299+00
+76	mapdata	0071_space_base_mapdata_accessible	2024-08-27 09:57:46.008532+00
+77	mapdata	0002_fix_broken_spaces	2024-08-27 09:57:46.063211+00
+78	mapdata	0003_column_access_restriction	2024-08-27 09:57:46.126575+00
+79	mapdata	0004_mapupdate_types	2024-08-27 09:57:46.143054+00
+80	mapdata	0005_geometry_import_tag	2024-08-27 09:57:46.575212+00
+81	mapdata	0006_location_icon	2024-08-27 09:57:46.733351+00
+82	mapdata	0007_location_group_help_text	2024-08-27 09:57:46.897828+00
+83	mapdata	0008_validate_slug	2024-08-27 09:57:46.920409+00
+84	mapdata	0072_make_wifi_measurement_author_nullable	2024-08-27 09:57:46.997022+00
+85	mapdata	0073_locationgroup_hierarchy	2024-08-27 09:57:47.034252+00
+86	mapdata	0074_show_labels	2024-08-27 09:57:47.20163+00
+87	mapdata	0075_label_settings	2024-08-27 09:57:47.806179+00
+88	mapdata	0076_obstacle_color	2024-08-27 09:57:48.251462+00
+89	mapdata	0077_obstacle_altitude	2024-08-27 09:57:48.319484+00
+90	mapdata	0078_reports	2024-08-27 09:57:48.733881+00
+91	mapdata	0079_auto_20191224_1858	2024-08-27 09:57:48.879595+00
+92	mapdata	0080_auto_20191224_2203	2024-08-27 09:57:48.942036+00
+93	mapdata	0081_auto_20191225_1015	2024-08-27 09:57:49.233043+00
+94	mapdata	0082_dynamiclocation_position	2024-08-27 09:57:49.454565+00
+95	mapdata	0083_auto_20191227_1642	2024-08-27 09:57:49.53827+00
+96	mapdata	0084_position_timeout	2024-08-27 09:57:49.562811+00
+97	mapdata	0085_locationgroupcategory_allow_dynamic_locations	2024-08-27 09:57:49.581141+00
+98	mapdata	0086_django_4_0	2024-08-27 09:57:53.433557+00
+99	contenttypes	0002_remove_content_type_name	2024-08-27 09:57:53.5103+00
+100	auth	0002_alter_permission_name_max_length	2024-08-27 09:57:53.575171+00
+101	auth	0003_alter_user_email_max_length	2024-08-27 09:57:53.599379+00
+102	auth	0004_alter_user_username_opts	2024-08-27 09:57:53.623728+00
+103	auth	0005_alter_user_last_login_null	2024-08-27 09:57:53.647635+00
+104	auth	0006_require_contenttypes_0002	2024-08-27 09:57:53.651058+00
+105	auth	0007_alter_validators_add_error_messages	2024-08-27 09:57:53.672943+00
+106	auth	0008_alter_user_username_max_length	2024-08-27 09:57:53.703935+00
+107	control	0001_initial	2024-08-27 09:57:53.777867+00
+108	control	0002_userpermissions_access_all	2024-08-27 09:57:53.802912+00
+109	control	0003_auto_20171210_1452	2024-08-27 09:57:53.827703+00
+110	control	0004_more_user_permissions	2024-08-27 09:57:53.893158+00
+111	control	0005_editor_mapdata_permissions	2024-08-27 09:57:53.942208+00
+112	control	0006_user_space_access	2024-08-27 09:57:54.104337+00
+113	control	0007_userpermissions_manage_map_updates	2024-08-27 09:57:54.242443+00
+114	control	0008_userpermissions_reports	2024-08-27 09:57:54.36221+00
+115	control	0009_django_4_0	2024-08-27 09:57:54.607086+00
+116	control	0010_userpermissions_mesh_control	2024-08-27 09:57:54.658528+00
+117	api	0001_initial	2024-08-27 09:57:54.737125+00
+118	api	0002_django_4_0	2024-08-27 09:57:54.802191+00
+119	api	0003_rename_token_logintoken_secret	2024-08-27 09:57:55.102916+00
+120	api	0004_alter_secret_name	2024-08-27 09:57:55.132302+00
+121	auth	0009_alter_user_last_name_max_length	2024-08-27 09:57:55.16147+00
+122	auth	0010_alter_group_name_max_length	2024-08-27 09:57:55.350028+00
+123	auth	0011_update_proxy_permissions	2024-08-27 09:57:55.41671+00
+124	auth	0012_alter_user_first_name_max_length	2024-08-27 09:57:55.444353+00
+125	control	0011_remove_userpermissions_api_secret	2024-08-27 09:57:55.492785+00
+126	control	0012_userpermissions_grant_unlimited_access	2024-08-27 09:57:55.541242+00
+127	control	0013_userpermissions_nonpublic_themes	2024-08-27 09:57:55.592623+00
+128	control	0014_userpermissions_sources_access	2024-08-27 09:57:55.644732+00
+129	editor	0001_initial	2024-08-27 09:57:56.597311+00
+130	editor	0002_auto_20170612_1615	2024-08-27 09:57:56.601125+00
+131	editor	0003_auto_20170618_1942	2024-08-27 09:57:56.604448+00
+132	editor	0004_auto_20170620_0934	2024-08-27 09:57:56.607744+00
+133	editor	0005_auto_20170627_0027	2024-08-27 09:57:56.610979+00
+134	editor	0006_auto_20170629_1222	2024-08-27 09:57:56.614322+00
+135	editor	0007_auto_20170629_1327	2024-08-27 09:57:56.618568+00
+136	editor	0008_auto_20170629_1450	2024-08-27 09:57:56.622841+00
+137	editor	0009_auto_20170701_1218	2024-08-27 09:57:56.627082+00
+138	editor	0010_auto_20170704_1431	2024-08-27 09:57:56.631272+00
+139	editor	0011_auto_20170704_1640	2024-08-27 09:57:56.635557+00
+140	editor	0012_remove_changeset_session_id	2024-08-27 09:57:56.63978+00
+141	editor	0013_remove_changesetupdate_session_user	2024-08-27 09:57:56.643985+00
+142	editor	0014_last_update_foreign_key	2024-08-27 09:57:56.64818+00
+143	editor	0015_changeset_last_state_update	2024-08-27 09:57:56.65161+00
+144	editor	0016_auto_20170705_1938	2024-08-27 09:57:56.655023+00
+145	editor	0017_changeset_map_update	2024-08-27 09:57:56.658389+00
+146	editor	0018_changeset_last_cleaned_with	2024-08-27 09:57:56.661636+00
+147	editor	0019_permissions	2024-08-27 09:57:56.664991+00
+148	editor	0020_remove_permissions	2024-08-27 09:57:56.668251+00
+149	editor	0021_auto_20180918_1736	2024-08-27 09:57:56.671549+00
+150	editor	0002_django_4_0	2024-08-27 09:57:57.034555+00
+151	editor	0003_changedobject_json_encoder	2024-08-27 09:57:57.054668+00
+152	mapdata	0087_rangingbeacon	2024-08-27 09:57:57.163656+00
+153	mapdata	0088_remove_position_api_secret	2024-08-27 09:57:57.195682+00
+154	mapdata	0089_groundaltitude	2024-08-27 09:57:57.485463+00
+155	mapdata	0090_alter_report_author	2024-08-27 09:57:57.558095+00
+156	mapdata	0091_area_main_point	2024-08-27 09:57:57.608702+00
+157	mapdata	0092_accesspermission_by_group	2024-08-27 09:57:57.94174+00
+158	mapdata	0093_public_accessrestriction	2024-08-27 09:57:57.997669+00
+159	mapdata	0094_hub_import_prepare	2024-08-27 09:57:58.272683+00
+160	mapdata	0095_import_block	2024-08-27 09:57:58.851733+00
+161	mapdata	0095_accesspermission_for_session	2024-08-27 09:57:59.045496+00
+162	mapdata	0096_merge_20231225_2216	2024-08-27 09:57:59.048283+00
+163	mapdata	0097_longer_import_tag	2024-08-27 09:57:59.686923+00
+164	mapdata	0098_report_import_tag	2024-08-27 09:57:59.740631+00
+165	mapdata	0099_theming	2024-08-27 09:58:00.180053+00
+166	mapdata	0100_obstaclegroup_color_data	2024-08-27 09:58:00.261418+00
+167	mapdata	0101_remove_obstacle_color	2024-08-27 09:58:00.343321+00
+168	mapdata	0102_rename_bssid_rangingbeacon_wifi_bssid_and_more	2024-08-27 09:58:00.744145+00
+169	mapdata	0103_report_flow_overhaul	2024-08-27 09:58:01.267908+00
+170	mapdata	0104_theme_color_css_grid_and_more	2024-08-27 09:58:01.451199+00
+171	mapdata	0105_alter_theme_color_background_and_more	2024-08-27 09:58:01.507173+00
+172	mapdata	0106_rename_wifi_to_beaconmeasurement	2024-08-27 09:58:01.778579+00
+173	mesh	0001_initial	2024-08-27 09:58:01.897982+00
+174	mesh	0002_alter_firmware_unique_together_meshnode_firmware_and_more	2024-08-27 09:58:01.941023+00
+175	mesh	0003_meshnode_name	2024-08-27 09:58:01.951991+00
+176	mesh	0004_relay_vs_src_node_and_remove_firmware	2024-08-27 09:58:02.211169+00
+177	mesh	0005_meshnode_last_signin	2024-08-27 09:58:02.220932+00
+178	mesh	0006_rename_route_meshnode_uplink	2024-08-27 09:58:02.244607+00
+179	mesh	0007_nodemessage_message_type_new	2024-08-27 09:58:02.370616+00
+180	mesh	0008_firmwarebuild_firmwarebuildboard_firmwareversion_and_more	2024-08-27 09:58:02.784016+00
+181	mesh	0009_meshuplink	2024-08-27 09:58:03.018144+00
+182	mesh	0010_otaupdate_otaupdaterecipient	2024-08-27 09:58:03.237301+00
+183	mesh	0011_meshnode_address_validate	2024-08-27 09:58:03.327313+00
+184	mesh	0012_otaupdaterecipient_status_and_more	2024-08-27 09:58:03.363442+00
+185	mesh	0013_meshnode_upstream_alter_nodemessage_message_type	2024-08-27 09:58:03.473797+00
+186	mesh	0014_remove_meshnode_name	2024-08-27 09:58:03.485254+00
+187	routing	0001_routeoptions	2024-08-27 09:58:03.590206+00
+188	routing	0002_django_4_0	2024-08-27 09:58:03.724786+00
+189	sessions	0001_initial	2024-08-27 09:58:03.753999+00
+190	site	0001_announcement	2024-08-27 09:58:03.773676+00
+191	site	0002_announcement_tweaks	2024-08-27 09:58:04.028622+00
+192	site	0003_siteupdate	2024-08-27 09:58:04.041775+00
+193	site	0004_siteupdate_tweaks	2024-08-27 09:58:04.048811+00
+194	site	0005_siteupdate_default_related_name	2024-08-27 09:58:04.055683+00
+195	site	0006_django_4_0	2024-08-27 09:58:04.145531+00
+196	mapdata	0001_squashed_2018	2024-08-27 09:58:04.152164+00
+197	editor	0001_squashed_2018	2024-08-27 09:58:04.15528+00
+198	mapdata	0107_altitudearea_multiple_points	2024-09-24 10:03:02.577602+00
+199	mapdata	0108_in_legend	2024-09-24 10:03:02.833749+00
+200	mapdata	0109_accesspermissionssogrant_accesspermission_sso_grant	2024-09-24 10:03:03.120676+00
+201	mapdata	0110_theme_icon_path_theme_leaflet_marker_config	2024-09-24 10:03:03.142018+00
 \.
 
 
@@ -3223,35 +3224,35 @@ COPY public.django_migrations (id, app, name, applied) FROM stdin;
 --
 
 COPY public.django_session (session_key, session_data, expire_date) FROM stdin;
-amvzk9pgex1m82ry1kzdx25pszsej2or	e30:1sisys:ZBLYTXPW4Mst-LCrO5xpvF3ncqA7l9oZVXwrhyE4wWQ	2024-09-10 11:59:18.364971+02
-4hovxfellnv5gkn8gvpjkg41m1723c50	e30:1snM7G:UekKIessh996E-RmJDoSZpNXjv1WZlcXCyTU2vebGSA	2024-09-22 19:54:26.072226+02
-dv9skqjm3ux1p9nluyuu56n5sso8xgh5	.eJxVjrkOwyAQRP9la8sCfHCU6fMNCHY3hhy2ZOMqyr8HSy6SdubN07zBh70kv2-8-kzgQELzm8WAD56Pgu5hnpYWl7msObYH0p7t1l4X4uflZP8EKWyprmM0QySpUXcChVRS4mCiMdwba6ymfuy0soMVo2aBpCjoUSlx642oy6CqFFM9wBsXcLIByitj8Uy55HkCV9adGyiJXwxOfL4COUZd:1sqV5O:ojREBcqoUHbyE-TRbY9cEXF3RPxC4y-kcAr3qboRQtU	2024-10-01 12:05:30.172933+02
-5xe6jji23iln8m5xvo0vyfe5eebi5chr	e30:1st1ml:tbKISLK_GjatJxEjzSyqJJuDy4JDglctKtfWbCwkM_8	2024-10-08 11:24:43.211555+02
-fworhxwo4qsqrhlvpddnf6h59higwz3t	e30:1sqU0l:MkZWje9AwTXlTXak9zAoh7yOKlrrR3xrEmhWTIyTD2I	2024-10-01 10:56:39.666121+02
-l8miuu132yek6hqkv38ae27nwbzpwhik	e30:1sqU0l:MkZWje9AwTXlTXak9zAoh7yOKlrrR3xrEmhWTIyTD2I	2024-10-01 10:56:39.677817+02
-kbx8kfya72l81fzz9ii640h5n0lmwg9i	eyJ0aGVtZSI6MH0:1st1ns:K_Y6Ur37_ksB3hSVBBU9porQ8g8jlxo4hlQVNUU_72w	2024-10-08 11:25:52.412981+02
-fwflkpv9b5xy8q72cbe6q429mfspzww7	.eJxNzDEKgDAMBdC7_NlFx16mBBuhGE1po0XEu1vRwfUN70TWzdhrsqhrgTuxaGA4TFSMi6FDJZl9ScyhceCJNnn5sCOx75uSiNafDY_tGkOz3JYcx-_HqnkhwXXdjEorUQ:1sne7R:51tDVOqUFko6t1YzgnBM3LNjJ0Y0SnT5HsKGu_qM614	2024-09-23 15:07:49.089044+02
-q8m07j89qos02p9auhqky6pp03ob2krz	e30:1sngGx:7eKDZWGa-25u7FaYQlzNsrnrCUr5sMT1yK9cptHUN5E	2024-09-23 17:25:47.510524+02
-27nlikabtzgx9twchu43xq8s4r3rv1du	e30:1sngGx:7eKDZWGa-25u7FaYQlzNsrnrCUr5sMT1yK9cptHUN5E	2024-09-23 17:25:47.562451+02
-vnbjrnbm0qrwaiu3b3zv1u5krc7lov49	e30:1sjbnL:theokb1P_6Ah1vG1iyD7OuL4Wa5hyLIr37tmMz-Yi9Q	2024-09-12 11:50:23.897761+02
-51wj5enr83qlh1y8m9gxfbvx2sqsgq07	e30:1sjbnL:theokb1P_6Ah1vG1iyD7OuL4Wa5hyLIr37tmMz-Yi9Q	2024-09-12 11:50:23.905553+02
-ei17awdyef1h0cf88icch72tt72l904x	e30:1snIBI:6YTHXawaY6C4mhclD2aS52Mtplo71U1svQ0R1wgF1aQ	2024-09-22 15:42:20.810821+02
-kxjxyug1szrlfxmgpcqhzv22hwdsdfb7	e30:1snIBI:6YTHXawaY6C4mhclD2aS52Mtplo71U1svQ0R1wgF1aQ	2024-09-22 15:42:20.891774+02
-2sqgh1eez736yycp9ye1vfn57zpgr96z	e30:1sngSo:82f8NvHNkGa6KiC_xppFSubGLpuWHpHvlAPlkblQrR4	2024-09-23 17:38:02.237571+02
-7c4pat9ia3590od8nnlkuyw5rqkkixtv	e30:1sngSo:82f8NvHNkGa6KiC_xppFSubGLpuWHpHvlAPlkblQrR4	2024-09-23 17:38:02.347145+02
-fsunuzk5s3j41te85rqqzws0y3mt9ihl	.eJxVjrkOwyAQRP9la8sCfHCU6fMNCHY3hhy2ZOMqyr8HSy6SdubN07zBh70kv2-8-kzgQELzm8WAD56Pgu5hnpYWl7msObYH0p7t1l4X4uflZP8EKWyprmM0QySpUXcChVRS4mCiMdwba6ymfuy0soMVo2aBpCjoUSlx642oy6CqtCR-MTjRAKZ6hTcu4FQDlFfG4plyyfMErqw7f77shEZe:1stlXP:u8QsfdZbgKrz7zquI3z3RuCNIFKLZyTZ9zrJCdBdSoU	2024-10-10 12:15:55.164456+02
-id9pv62xyn92ahnefr4210edrkodeuf3	e30:1sze1A:fFBWSCLSxkvcG4IUMiMWFzeoH5Lwbp1LQjRtIr4kR8Y	2024-10-26 17:26:56.468238+02
-rgyoqr9kt4q5hp2x1zkp1estiv1bzw5c	e30:1t0Fne:EyQsIXzexCQvCqWzuahDcCWoXcV3ID9XQiT79fCRvFg	2024-10-28 08:47:30.932495+01
-ci83dj1uq0qyowc0kgld08nedz3zkzzi	e30:1stibl:N7SVwoTd7Gn1cV1AClys4ydxGXZhZs4Ird7PTWdIBCA	2024-10-10 09:08:13.07702+02
-bqymqssw92jj8k67t1qb7jka29z7v8mc	.eJxNzEEKgCAQQNG7zLpNLb2MSI4gWSM6JiLevYlctH18fodEhVFTZE9XBtXhJIugwJnMmBkWqCYcOkdEK2zRmRI-btwi6lXU3OTtz7bXQqAqluSS_D7_Mx3jAV-QKts:1t0GJi:QGcAJpkUuYtNynAmgbMEJKJaAsYtcyFlECfdH-m7Ugk	2024-10-28 09:20:38.207074+01
-oti396jz8a5is79ywv018b9c0yzyrv20	e30:1t2vKs:6_9G7fpVV5H9eGLlXMNIS--xw4zQDvdFhAuWkx_Imb0	2024-11-04 17:32:50.494131+01
-frh7shgsyutsdk76ko6va3adqhwl24pt	e30:1t2vKs:6_9G7fpVV5H9eGLlXMNIS--xw4zQDvdFhAuWkx_Imb0	2024-11-04 17:32:50.563172+01
-du6i1y35imkqnpjw9eontbwhlxcthnyr	e30:1t3xkc:mcf8V6aMWq9oCnuWdB042ZsvkbZOvU6bEJ6C28MFNxo	2024-11-07 14:19:42.27057+01
-22ky2dvil1mzjkge4l2w781k9llxrun4	.eJxVjkEOwiAURO_CuiGAtECX7j0Dgf-_BTVtAnRlvLs06UK3M29e5s182Fvye6XiM7KZSTb8ZjHAk9ajwEdYl43DtraSIz8QfraV3zak1_Vk_wQp1NTXMdoxojRgLgKEVFLCaKO1pK2zzqCeLka50YnJkABUGMyklLhrK_oyqC6F1A9QpcZmPTDMhaB5wtzyurC5lZ0-X1FqQ3M:1t4HCF:le4fcDuRrAolkiAZByxprxoBdC3KTDEtSt3V5ahm8xc	2024-11-08 11:05:31.458212+01
-m5fqocfdl1ano9n7zm0abev7rc1ygm1h	e30:1t3xkc:mcf8V6aMWq9oCnuWdB042ZsvkbZOvU6bEJ6C28MFNxo	2024-11-07 14:19:42.426527+01
-flff3bukysca7jty72fyvnpog017eh4o	e30:1t3xlG:1hmMWR5LVInGbxmw92Yu6EFzs9p6BYFKz6mpKvfcut8	2024-11-07 14:20:22.134477+01
-32e3enrs3s3j6br4liejz6kw1ag9rdmp	e30:1t3xlG:1hmMWR5LVInGbxmw92Yu6EFzs9p6BYFKz6mpKvfcut8	2024-11-07 14:20:22.185861+01
-ow694isitijclav0ap763b3woz0hvm4l	e30:1t2s5t:OfrKMJvPRdweQkRSgNLNB-loXQZRdfX-uQgJVAWNJj8	2024-11-04 14:05:09.134775+01
+amvzk9pgex1m82ry1kzdx25pszsej2or	e30:1sisys:ZBLYTXPW4Mst-LCrO5xpvF3ncqA7l9oZVXwrhyE4wWQ	2024-09-10 09:59:18.364971+00
+4hovxfellnv5gkn8gvpjkg41m1723c50	e30:1snM7G:UekKIessh996E-RmJDoSZpNXjv1WZlcXCyTU2vebGSA	2024-09-22 17:54:26.072226+00
+dv9skqjm3ux1p9nluyuu56n5sso8xgh5	.eJxVjrkOwyAQRP9la8sCfHCU6fMNCHY3hhy2ZOMqyr8HSy6SdubN07zBh70kv2-8-kzgQELzm8WAD56Pgu5hnpYWl7msObYH0p7t1l4X4uflZP8EKWyprmM0QySpUXcChVRS4mCiMdwba6ymfuy0soMVo2aBpCjoUSlx642oy6CqFFM9wBsXcLIByitj8Uy55HkCV9adGyiJXwxOfL4COUZd:1sqV5O:ojREBcqoUHbyE-TRbY9cEXF3RPxC4y-kcAr3qboRQtU	2024-10-01 10:05:30.172933+00
+5xe6jji23iln8m5xvo0vyfe5eebi5chr	e30:1st1ml:tbKISLK_GjatJxEjzSyqJJuDy4JDglctKtfWbCwkM_8	2024-10-08 09:24:43.211555+00
+fworhxwo4qsqrhlvpddnf6h59higwz3t	e30:1sqU0l:MkZWje9AwTXlTXak9zAoh7yOKlrrR3xrEmhWTIyTD2I	2024-10-01 08:56:39.666121+00
+l8miuu132yek6hqkv38ae27nwbzpwhik	e30:1sqU0l:MkZWje9AwTXlTXak9zAoh7yOKlrrR3xrEmhWTIyTD2I	2024-10-01 08:56:39.677817+00
+kbx8kfya72l81fzz9ii640h5n0lmwg9i	eyJ0aGVtZSI6MH0:1st1ns:K_Y6Ur37_ksB3hSVBBU9porQ8g8jlxo4hlQVNUU_72w	2024-10-08 09:25:52.412981+00
+fwflkpv9b5xy8q72cbe6q429mfspzww7	.eJxNzDEKgDAMBdC7_NlFx16mBBuhGE1po0XEu1vRwfUN70TWzdhrsqhrgTuxaGA4TFSMi6FDJZl9ScyhceCJNnn5sCOx75uSiNafDY_tGkOz3JYcx-_HqnkhwXXdjEorUQ:1sne7R:51tDVOqUFko6t1YzgnBM3LNjJ0Y0SnT5HsKGu_qM614	2024-09-23 13:07:49.089044+00
+q8m07j89qos02p9auhqky6pp03ob2krz	e30:1sngGx:7eKDZWGa-25u7FaYQlzNsrnrCUr5sMT1yK9cptHUN5E	2024-09-23 15:25:47.510524+00
+27nlikabtzgx9twchu43xq8s4r3rv1du	e30:1sngGx:7eKDZWGa-25u7FaYQlzNsrnrCUr5sMT1yK9cptHUN5E	2024-09-23 15:25:47.562451+00
+vnbjrnbm0qrwaiu3b3zv1u5krc7lov49	e30:1sjbnL:theokb1P_6Ah1vG1iyD7OuL4Wa5hyLIr37tmMz-Yi9Q	2024-09-12 09:50:23.897761+00
+51wj5enr83qlh1y8m9gxfbvx2sqsgq07	e30:1sjbnL:theokb1P_6Ah1vG1iyD7OuL4Wa5hyLIr37tmMz-Yi9Q	2024-09-12 09:50:23.905553+00
+ei17awdyef1h0cf88icch72tt72l904x	e30:1snIBI:6YTHXawaY6C4mhclD2aS52Mtplo71U1svQ0R1wgF1aQ	2024-09-22 13:42:20.810821+00
+kxjxyug1szrlfxmgpcqhzv22hwdsdfb7	e30:1snIBI:6YTHXawaY6C4mhclD2aS52Mtplo71U1svQ0R1wgF1aQ	2024-09-22 13:42:20.891774+00
+2sqgh1eez736yycp9ye1vfn57zpgr96z	e30:1sngSo:82f8NvHNkGa6KiC_xppFSubGLpuWHpHvlAPlkblQrR4	2024-09-23 15:38:02.237571+00
+7c4pat9ia3590od8nnlkuyw5rqkkixtv	e30:1sngSo:82f8NvHNkGa6KiC_xppFSubGLpuWHpHvlAPlkblQrR4	2024-09-23 15:38:02.347145+00
+fsunuzk5s3j41te85rqqzws0y3mt9ihl	.eJxVjrkOwyAQRP9la8sCfHCU6fMNCHY3hhy2ZOMqyr8HSy6SdubN07zBh70kv2-8-kzgQELzm8WAD56Pgu5hnpYWl7msObYH0p7t1l4X4uflZP8EKWyprmM0QySpUXcChVRS4mCiMdwba6ymfuy0soMVo2aBpCjoUSlx642oy6CqtCR-MTjRAKZ6hTcu4FQDlFfG4plyyfMErqw7f77shEZe:1stlXP:u8QsfdZbgKrz7zquI3z3RuCNIFKLZyTZ9zrJCdBdSoU	2024-10-10 10:15:55.164456+00
+id9pv62xyn92ahnefr4210edrkodeuf3	e30:1sze1A:fFBWSCLSxkvcG4IUMiMWFzeoH5Lwbp1LQjRtIr4kR8Y	2024-10-26 15:26:56.468238+00
+rgyoqr9kt4q5hp2x1zkp1estiv1bzw5c	e30:1t0Fne:EyQsIXzexCQvCqWzuahDcCWoXcV3ID9XQiT79fCRvFg	2024-10-28 07:47:30.932495+00
+ci83dj1uq0qyowc0kgld08nedz3zkzzi	e30:1stibl:N7SVwoTd7Gn1cV1AClys4ydxGXZhZs4Ird7PTWdIBCA	2024-10-10 07:08:13.07702+00
+bqymqssw92jj8k67t1qb7jka29z7v8mc	.eJxNzEEKgCAQQNG7zLpNLb2MSI4gWSM6JiLevYlctH18fodEhVFTZE9XBtXhJIugwJnMmBkWqCYcOkdEK2zRmRI-btwi6lXU3OTtz7bXQqAqluSS_D7_Mx3jAV-QKts:1t0GJi:QGcAJpkUuYtNynAmgbMEJKJaAsYtcyFlECfdH-m7Ugk	2024-10-28 08:20:38.207074+00
+oti396jz8a5is79ywv018b9c0yzyrv20	e30:1t2vKs:6_9G7fpVV5H9eGLlXMNIS--xw4zQDvdFhAuWkx_Imb0	2024-11-04 16:32:50.494131+00
+frh7shgsyutsdk76ko6va3adqhwl24pt	e30:1t2vKs:6_9G7fpVV5H9eGLlXMNIS--xw4zQDvdFhAuWkx_Imb0	2024-11-04 16:32:50.563172+00
+du6i1y35imkqnpjw9eontbwhlxcthnyr	e30:1t3xkc:mcf8V6aMWq9oCnuWdB042ZsvkbZOvU6bEJ6C28MFNxo	2024-11-07 13:19:42.27057+00
+22ky2dvil1mzjkge4l2w781k9llxrun4	.eJxVjkEOwiAURO_CuiGAtECX7j0Dgf-_BTVtAnRlvLs06UK3M29e5s182Fvye6XiM7KZSTb8ZjHAk9ajwEdYl43DtraSIz8QfraV3zak1_Vk_wQp1NTXMdoxojRgLgKEVFLCaKO1pK2zzqCeLka50YnJkABUGMyklLhrK_oyqC6F1A9QpcZmPTDMhaB5wtzyurC5lZ0-X1FqQ3M:1t4HCF:le4fcDuRrAolkiAZByxprxoBdC3KTDEtSt3V5ahm8xc	2024-11-08 10:05:31.458212+00
+m5fqocfdl1ano9n7zm0abev7rc1ygm1h	e30:1t3xkc:mcf8V6aMWq9oCnuWdB042ZsvkbZOvU6bEJ6C28MFNxo	2024-11-07 13:19:42.426527+00
+flff3bukysca7jty72fyvnpog017eh4o	e30:1t3xlG:1hmMWR5LVInGbxmw92Yu6EFzs9p6BYFKz6mpKvfcut8	2024-11-07 13:20:22.134477+00
+32e3enrs3s3j6br4liejz6kw1ag9rdmp	e30:1t3xlG:1hmMWR5LVInGbxmw92Yu6EFzs9p6BYFKz6mpKvfcut8	2024-11-07 13:20:22.185861+00
+ow694isitijclav0ap763b3woz0hvm4l	e30:1t2s5t:OfrKMJvPRdweQkRSgNLNB-loXQZRdfX-uQgJVAWNJj8	2024-11-04 13:05:09.134775+00
 \.
 
 
@@ -3260,6 +3261,11 @@ ow694isitijclav0ap763b3woz0hvm4l	e30:1t2s5t:OfrKMJvPRdweQkRSgNLNB-loXQZRdfX-uQgJ
 --
 
 COPY public.editor_changedobject (id, created, existing_object_pk, updated_fields, m2m_added, m2m_removed, deleted, changeset_id, content_type_id) FROM stdin;
+23	2024-10-27 10:01:39.992448+00	\N	{"category": 5, "can_describe": false, "label_settings": 1, "title__i18n__en": "Crane Hall BOF meetings"}	{}	{}	f	5	34
+25	2024-10-28 10:27:30.241382+00	\N	{"space": 36, "geometry": {"type": "Point", "coordinates": [236.47, 217.71]}, "external_url": "https://www.sfscon.it/tracks/crane-hall-bof-meetings-2024/", "title__i18n__en": "Crane Hall BOF meetings"}	{}	{}	f	6	36
+26	2024-10-28 10:27:56.272718+00	152	{}	{}	{}	t	6	34
+27	2024-10-28 10:38:53.342045+00	153	{"geometry": {"type": "Point", "coordinates": [222.31, 217.56]}, "label_settings": 1}	{}	{}	f	7	36
+28	2024-10-28 10:54:03.336259+00	106	{"title__i18n__en": "Access to President's Office (NOI Board)"}	{}	{}	f	8	36
 \.
 
 
@@ -3268,6 +3274,10 @@ COPY public.editor_changedobject (id, created, existing_object_pk, updated_field
 --
 
 COPY public.editor_changeset (id, created, state, title, description, assigned_to_id, author_id, last_change_id, last_cleaned_with_id, last_state_update_id, last_update_id, map_update_id) FROM stdin;
+5	2024-10-27 10:01:39.987629+00	applied	Add Crane Hall BOF meetings	add the POI for the BOF meetings in the Crane Hall	1	1	12	1822	16	16	1823
+6	2024-10-27 10:15:56.996907+00	applied	Add Crane Hall BOF meetings	Add BOF meetings location	1	1	19	1823	23	23	1824
+7	2024-10-28 10:38:53.340637+00	applied	Change label BOF meetings	Add and move BOF meetings label	1	1	\N	1824	27	27	1825
+8	2024-10-28 10:54:03.335676+00	applied	Modify Access President room label	Add NOI Board to label	1	1	\N	1825	31	31	1826
 \.
 
 
@@ -3276,6 +3286,27 @@ COPY public.editor_changeset (id, created, state, title, description, assigned_t
 --
 
 COPY public.editor_changesetupdate (id, datetime, comment, state, title, description, objects_changed, assigned_to_id, changeset_id, user_id) FROM stdin;
+11	2024-10-27 10:05:24.122876+00	\N		\N	\N	t	\N	5	1
+12	2024-10-27 10:08:25.573123+00	\N		\N	\N	t	\N	5	1
+13	2024-10-27 10:10:06.688136+00	\N		Add Crane Hall BOF meetings	add the POI for the BOF meetings in the Crane Hall	f	\N	5	1
+14	2024-10-27 10:10:15.582027+00	\N	proposed	\N	\N	f	\N	5	1
+15	2024-10-27 10:10:30.161808+00	\N	review	\N	\N	f	1	5	1
+16	2024-10-27 10:10:35.45748+00	\N	applied	\N	\N	f	\N	5	1
+17	2024-10-27 10:15:57.171981+00	\N		\N	\N	t	\N	6	\N
+18	2024-10-28 10:27:30.247929+00	\N		\N	\N	t	\N	6	1
+19	2024-10-28 10:27:56.27351+00	\N		\N	\N	t	\N	6	1
+20	2024-10-28 10:35:07.946298+00	\N		Add Crane Hall BOF meetings	Add BOF meetings location	f	\N	6	1
+21	2024-10-28 10:35:10.718123+00	\N	proposed	\N	\N	f	\N	6	1
+22	2024-10-28 10:35:16.868547+00	\N	review	\N	\N	f	1	6	1
+23	2024-10-28 10:35:30.293212+00	\N	applied	\N	\N	f	\N	6	1
+24	2024-10-28 10:39:55.938127+00	\N		Change label BOF meetings	Add and move BOF meetings label	f	\N	7	1
+25	2024-10-28 10:39:57.50337+00	\N	proposed	\N	\N	f	\N	7	1
+26	2024-10-28 10:39:59.544028+00	\N	review	\N	\N	f	1	7	1
+27	2024-10-28 10:40:03.615256+00	\N	applied	\N	\N	f	\N	7	1
+28	2024-10-28 10:55:26.062094+00	\N		Modify Access President room label	Add NOI Board to label	f	\N	8	1
+29	2024-10-28 10:55:27.527888+00	\N	proposed	\N	\N	f	\N	8	1
+30	2024-10-28 10:55:29.420802+00	\N	review	\N	\N	f	1	8	1
+31	2024-10-28 10:55:32.590528+00	\N	applied	\N	\N	f	\N	8	1
 \.
 
 
@@ -3332,57 +3363,72 @@ COPY public.mapdata_accessrestrictiongroup (id, titles) FROM stdin;
 --
 
 COPY public.mapdata_altitudearea (id, geometry, altitude, level_id, import_tag, points) FROM stdin;
-2	{"type": "Polygon", "coordinates": [[[276.49, 141.47], [276.48, 141.59], [276.49, 141.59], [276.35, 143.25], [273.93, 143.04], [273.21, 150.85], [270.11, 150.87], [270.12, 153.04], [269.81, 153.04], [269.81, 155.98], [269.78, 155.98], [269.78, 156.12], [269.88, 156.12], [269.88, 153.37], [334.06, 153.37], [334.06, 158.0], [367.13, 158.06], [367.13, 180.44], [350.0, 180.44], [350.0, 183.19], [299.12, 183.19], [299.12, 180.56], [283.56, 180.56], [283.56, 183.31], [274.81, 183.31], [274.81, 179.37], [274.46, 179.37], [274.46, 181.71], [272.72, 181.71], [272.72, 179.37], [272.69, 179.37], [272.69, 173.12], [268.0, 173.12], [268.0, 156.12], [268.02, 156.12], [268.03, 155.99], [268.01, 155.99], [267.97, 149.0], [271.18, 148.99], [271.9, 141.19], [274.02, 141.37], [274.04, 141.24], [276.49, 141.47]]]}	-3.45	10	\N	\N
-106	{"type": "MultiPolygon", "coordinates": [[[[338.21, 201.08], [338.21, 207.65], [343.99, 207.64], [343.99, 201.08], [338.21, 201.08]], [[342.74, 206.19], [339.69, 206.19], [339.69, 202.61], [342.74, 202.61], [342.74, 206.19]]], [[[426.99, 207.72], [426.99, 201.35], [421.64, 201.35], [421.64, 207.7], [426.99, 207.72]], [[422.62, 202.6], [425.57, 202.6], [425.57, 206.17], [422.62, 206.17], [422.62, 202.6]]]]}	5.00	37	\N	\N
-359	{"type": "MultiPolygon", "coordinates": [[[[248.37, 137.64], [252.89, 138.06], [252.91, 137.94], [252.6, 137.91], [252.61, 137.77], [248.66, 137.4], [249.04, 133.32], [248.93, 133.31], [248.95, 133.05], [248.79, 133.04], [248.37, 137.64]]], [[[269.97, 139.65], [269.98, 139.5], [269.75, 139.48], [269.76, 139.33], [258.38, 138.29], [258.37, 138.43], [258.05, 138.4], [258.04, 138.53], [269.97, 139.65]]], [[[276.53, 140.7], [274.13, 140.47], [274.1, 140.74], [276.5, 140.97], [276.53, 140.7]]], [[[272.66, 211.99], [274.54, 211.98], [274.54, 211.71], [272.66, 211.71], [272.66, 211.99]]]]}	0.50	2	\N	\N
-357	{"type": "MultiPolygon", "coordinates": [[[[248.55, 132.74], [248.07, 137.88], [253.14, 138.35], [253.18, 137.96], [252.91, 137.94], [252.89, 138.06], [248.37, 137.64], [248.79, 133.04], [248.95, 133.05], [248.98, 132.78], [248.55, 132.74]]], [[[270.22, 139.92], [270.26, 139.53], [269.98, 139.5], [269.97, 139.65], [258.04, 138.53], [258.05, 138.4], [257.77, 138.38], [257.73, 138.78], [270.22, 139.92]]], [[[274.08, 141.01], [276.48, 141.24], [276.5, 140.97], [274.1, 140.74], [274.08, 141.01]]]]}	0.33	2	\N	\N
-3	{"type": "Polygon", "coordinates": [[[272.79, 223.14], [272.72, 223.14], [272.72, 223.13], [274.51, 223.13], [280.61, 223.11], [280.61, 223.08], [275.82, 223.08], [275.81, 209.71], [283.49, 209.71], [283.49, 223.08], [282.75, 223.08], [282.75, 223.1], [284.05, 223.1], [284.05, 222.57], [284.46, 222.57], [284.46, 222.37], [284.04, 222.37], [284.05, 211.96], [301.6, 211.96], [301.6, 222.38], [288.02, 222.37], [288.02, 222.57], [299.94, 222.57], [299.94, 223.15], [304.78, 223.15], [304.78, 223.03], [302.25, 223.03], [302.16, 199.75], [315.52, 199.75], [315.52, 223.03], [306.51, 223.03], [306.51, 223.15], [316.04, 223.15], [316.04, 229.84], [306.67, 229.84], [306.67, 230.0], [315.52, 230.0], [315.52, 244.57], [302.23, 244.57], [302.23, 230.0], [304.96, 230.0], [304.96, 229.84], [301.62, 229.84], [301.62, 240.06], [282.67, 240.05], [282.67, 240.25], [283.45, 240.23], [283.45, 243.05], [280.8, 243.05], [280.8, 240.29], [281.88, 240.27], [281.88, 240.05], [280.84, 240.05], [280.82, 233.84], [276.4, 233.84], [276.4, 234.09], [280.54, 234.09], [280.56, 245.24], [275.09, 245.24], [275.09, 234.09], [275.19, 234.09], [275.19, 233.84], [274.49, 233.84], [274.49, 234.0], [272.79, 234.0], [272.79, 223.14]], [[286.29, 222.37], [286.15, 222.37], [286.14, 222.57], [286.29, 222.57], [286.29, 222.37]], [[298.97, 229.86], [288.95, 229.86], [288.95, 234.43], [298.97, 234.44], [298.97, 229.86]], [[285.82, 232.63], [285.98, 232.63], [285.98, 231.68], [285.82, 231.68], [285.82, 231.99], [283.95, 231.99], [283.95, 230.3], [286.45, 230.3], [286.45, 229.86], [283.46, 229.86], [283.46, 234.45], [286.45, 234.45], [286.45, 234.02], [283.95, 234.02], [283.95, 232.32], [285.82, 232.32], [285.82, 232.63]]]}	-5.00	10	\N	\N
-240	{"type": "Polygon", "coordinates": [[[272.65, 233.99], [272.65, 230.01], [283.6, 230.01], [283.6, 233.99], [272.65, 233.99]]]}	4.60	37	\N	\N
+3	{"type": "Polygon", "coordinates": [[[272.79, 223.14], [272.72, 223.14], [272.72, 223.13], [274.51, 223.13], [280.61, 223.11], [280.61, 223.08], [275.82, 223.08], [275.81, 209.71], [283.49, 209.71], [283.49, 223.08], [282.75, 223.08], [282.75, 223.1], [284.05, 223.1], [284.05, 222.57], [284.46, 222.57], [284.46, 222.37], [284.04, 222.37], [284.05, 211.96], [301.6, 211.96], [301.6, 222.38], [288.02, 222.37], [288.02, 222.57], [299.94, 222.57], [299.94, 223.15], [304.78, 223.15], [304.78, 223.03], [302.25, 223.03], [302.16, 199.75], [315.52, 199.75], [315.52, 223.03], [306.51, 223.03], [306.51, 223.15], [316.04, 223.15], [316.04, 229.84], [306.67, 229.84], [306.67, 230.0], [315.52, 230.0], [315.52, 244.57], [302.23, 244.57], [302.23, 230.0], [304.96, 230.0], [304.96, 229.84], [301.62, 229.84], [301.62, 240.06], [282.67, 240.05], [282.67, 240.25], [283.45, 240.23], [283.45, 243.05], [280.8, 243.05], [280.8, 240.29], [281.88, 240.27], [281.88, 240.05], [280.84, 240.05], [280.82, 233.84], [276.4, 233.84], [276.4, 234.09], [280.54, 234.09], [280.56, 245.24], [275.09, 245.24], [275.09, 234.09], [275.19, 234.09], [275.19, 233.84], [274.49, 233.84], [274.49, 234.0], [272.79, 234.0], [272.79, 223.14]], [[286.29, 222.37], [286.15, 222.37], [286.14, 222.57], [286.29, 222.57], [286.29, 222.37]], [[288.95, 229.86], [288.95, 234.43], [298.97, 234.44], [298.97, 229.86], [288.95, 229.86]], [[285.98, 232.63], [285.98, 231.68], [285.82, 231.68], [285.82, 231.99], [283.95, 231.99], [283.95, 230.3], [286.45, 230.3], [286.45, 229.86], [283.46, 229.86], [283.46, 234.45], [286.45, 234.45], [286.45, 234.02], [283.95, 234.02], [283.95, 232.32], [285.82, 232.32], [285.82, 232.63], [285.98, 232.63]]]}	-5.00	10	\N	\N
+319	{"type": "Polygon", "coordinates": [[[248.98, 132.78], [248.95, 133.05], [248.93, 133.31], [249.58, 133.37], [249.25, 136.9], [252.65, 137.21], [252.6, 137.91], [252.91, 137.94], [253.18, 137.96], [253.44, 137.99], [257.51, 138.35], [257.77, 138.38], [258.05, 138.4], [258.37, 138.43], [258.42, 137.74], [269.81, 138.8], [269.75, 139.48], [269.98, 139.5], [270.26, 139.53], [270.53, 139.55], [271.7, 139.66], [271.72, 139.44], [271.74, 139.24], [271.87, 138.0], [267.04, 137.54], [267.11, 136.59], [272.35, 137.07], [273.26, 127.01], [272.34, 137.49], [273.55, 137.6], [273.54, 137.7], [272.35, 137.59], [272.17, 139.25], [274.22, 139.46], [274.18, 139.93], [276.59, 140.15], [276.8, 138.01], [276.29, 137.96], [276.29, 137.85], [278.73, 138.08], [278.78, 137.51], [278.88, 137.51], [278.8, 138.32], [278.45, 138.26], [277.93, 143.73], [298.3, 145.79], [300.23, 125.07], [280.22, 123.24], [279.93, 126.35], [279.8, 126.34], [280.09, 123.21], [278.08, 123.02], [278.29, 120.53], [277.97, 120.5], [277.98, 120.4], [279.71, 120.55], [280.1, 116.13], [277.53, 115.88], [277.11, 120.32], [277.19, 120.33], [277.18, 120.43], [276.83, 120.4], [276.85, 120.29], [276.97, 120.3], [277.36, 115.87], [274.35, 115.6], [273.92, 120.01], [276.07, 120.21], [276.06, 120.34], [275.97, 120.33], [275.97, 120.38], [275.85, 120.36], [275.85, 120.31], [273.93, 120.14], [273.72, 122.27], [275.64, 122.43], [275.71, 121.77], [275.82, 121.78], [275.72, 122.77], [273.65, 122.59], [273.65, 122.61], [265.19, 121.84], [264.98, 123.97], [254.68, 122.99], [253.85, 123.36], [253.29, 123.74], [252.79, 124.22], [252.34, 124.92], [251.29, 135.14], [261.95, 136.12], [261.87, 137.05], [259.39, 136.82], [250.34, 135.98], [250.34, 135.97], [250.26, 135.96], [250.88, 129.87], [249.67, 129.76], [249.68, 129.64], [249.27, 129.6], [249.0, 132.51], [248.98, 132.78]], [[249.64, 133.38], [249.66, 133.09], [249.67, 132.96], [249.64, 133.38]], [[295.26, 131.15], [295.29, 130.8], [297.19, 130.99], [297.16, 131.32], [295.26, 131.15]], [[295.63, 136.96], [295.67, 136.63], [296.01, 136.66], [295.99, 137.0], [295.63, 136.96]], [[295.7, 140.02], [295.36, 139.99], [295.39, 139.65], [295.73, 139.68], [295.7, 140.02]], [[289.4, 130.61], [289.43, 130.26], [291.34, 130.45], [291.31, 130.79], [289.4, 130.61]], [[289.73, 136.42], [289.76, 136.09], [290.1, 136.12], [290.07, 136.45], [289.73, 136.42]], [[289.8, 139.48], [289.45, 139.44], [289.48, 139.11], [289.83, 139.14], [289.8, 139.48]], [[283.53, 130.08], [283.56, 129.74], [285.47, 129.89], [285.43, 130.25], [283.53, 130.08]], [[283.88, 135.89], [283.91, 135.54], [284.27, 135.58], [284.23, 135.92], [283.88, 135.89]], [[283.59, 138.91], [283.62, 138.56], [283.99, 138.59], [283.95, 138.95], [283.59, 138.91]], [[279.08, 134.26], [279.5, 129.7], [277.69, 129.53], [277.76, 128.27], [279.62, 128.37], [279.67, 127.78], [279.79, 127.79], [279.01, 136.06], [278.92, 136.05], [278.97, 135.42], [277.16, 135.26], [277.27, 134.14], [279.08, 134.26]], [[270.93, 128.9], [271.03, 127.98], [272.81, 128.11], [272.71, 129.05], [270.93, 128.9]], [[270.45, 134.46], [270.5, 133.56], [272.32, 133.69], [272.23, 134.62], [270.45, 134.46]], [[267.48, 127.67], [267.49, 127.31], [268.85, 127.44], [268.81, 127.78], [267.48, 127.67]], [[266.82, 134.49], [266.86, 134.14], [268.22, 134.26], [268.16, 134.6], [266.82, 134.49]], [[264.1, 136.31], [265.24, 136.42], [265.16, 137.36], [264.05, 137.26], [264.1, 136.31]], [[263.35, 127.27], [263.38, 126.93], [264.74, 127.02], [264.71, 127.42], [263.35, 127.27]], [[262.7, 134.11], [262.73, 133.74], [264.11, 133.86], [264.07, 134.24], [262.7, 134.11]], [[260.54, 126.65], [260.5, 127.0], [259.35, 126.91], [259.25, 127.87], [258.86, 127.82], [259.01, 126.51], [260.54, 126.65]], [[258.74, 133.37], [259.89, 133.51], [259.85, 133.84], [258.32, 133.7], [258.46, 132.42], [258.85, 132.46], [258.74, 133.37]], [[253.0, 137.17], [253.08, 137.18], [252.66, 137.14], [253.0, 137.17]], [[253.08, 137.18], [253.05, 137.53], [253.07, 137.24], [253.08, 137.18]], [[253.05, 137.53], [256.28, 137.82], [253.48, 137.57], [253.22, 137.55], [253.05, 137.53]]]}	1.00	2	\N	\N
+106	{"type": "MultiPolygon", "coordinates": [[[[343.99, 201.08], [338.21, 201.08], [338.21, 207.65], [343.99, 207.64], [343.99, 201.08]], [[342.74, 202.61], [342.74, 206.19], [339.69, 206.19], [339.69, 202.61], [342.74, 202.61]]], [[[421.64, 207.7], [426.99, 207.72], [426.99, 201.35], [421.64, 201.35], [421.64, 207.7]], [[422.62, 206.17], [422.62, 202.6], [425.57, 202.6], [425.57, 206.17], [422.62, 206.17]]]]}	5.00	37	\N	\N
+277	{"type": "Polygon", "coordinates": [[[284.05, 210.67], [284.05, 209.31], [301.53, 209.31], [301.53, 210.67], [284.05, 210.67]]]}	-4.23	11	\N	\N
+4	{"type": "MultiPolygon", "coordinates": [[[[198.82, 114.05], [198.77, 115.5], [200.53, 115.55], [200.48, 114.05], [198.82, 114.05]]], [[[270.36, 198.24], [270.36, 198.23], [268.92, 198.23], [270.36, 198.24]]], [[[343.92, 157.08], [353.88, 157.08], [362.27, 157.89], [353.97, 157.05], [343.92, 157.08]]], [[[270.62, 201.23], [269.47, 201.23], [269.47, 201.24], [269.44, 201.24], [269.44, 201.23], [251.96, 201.23], [251.96, 200.52], [259.45, 200.52], [259.42, 192.41], [240.04, 192.41], [240.04, 200.52], [250.47, 200.52], [250.46, 201.23], [239.73, 201.23], [239.73, 198.92], [235.34, 198.92], [235.34, 201.25], [215.82, 201.25], [215.82, 203.44], [235.53, 203.44], [235.53, 203.75], [239.58, 203.75], [239.59, 205.04], [239.59, 203.39], [263.91, 203.39], [263.91, 206.18], [263.73, 206.18], [263.73, 206.1], [260.14, 206.1], [260.14, 208.71], [264.21, 208.69], [264.21, 207.11], [263.73, 207.11], [263.73, 206.9], [263.91, 206.9], [263.91, 206.91], [265.21, 206.91], [265.21, 207.17], [264.39, 207.17], [264.39, 208.67], [266.72, 208.66], [266.72, 207.17], [265.95, 207.17], [265.95, 206.91], [266.94, 206.91], [266.94, 206.89], [267.11, 206.89], [267.11, 207.16], [266.89, 207.16], [266.9, 208.67], [270.3, 208.68], [270.3, 206.08], [267.12, 206.09], [267.12, 206.1], [266.94, 206.1], [266.94, 203.47], [269.44, 203.47], [269.44, 203.46], [269.46, 203.46], [269.46, 203.47], [270.63, 203.47], [270.63, 204.15], [270.4, 204.15], [270.4, 203.71], [267.26, 203.71], [267.26, 205.83], [270.4, 205.8], [270.4, 205.08], [270.64, 205.08], [270.64, 206.15], [272.37, 206.15], [272.37, 205.42], [272.66, 205.42], [272.66, 207.36], [274.5, 207.36], [274.5, 207.3], [274.99, 207.3], [274.99, 205.44], [275.11, 205.44], [275.11, 205.42], [283.42, 205.42], [283.42, 194.36], [283.68, 194.36], [283.68, 194.29], [272.7, 194.29], [272.7, 194.23], [302.38, 194.13], [302.41, 200.83], [337.54, 200.75], [337.54, 185.02], [352.38, 185.02], [352.38, 180.37], [422.1, 180.52], [422.1, 184.79], [427.34, 184.8], [427.48, 198.98], [426.57, 198.98], [426.56, 190.86], [414.02, 190.85], [414.03, 189.37], [413.95, 189.37], [413.95, 189.21], [414.01, 189.21], [414.01, 186.02], [411.86, 186.02], [411.86, 189.21], [412.34, 189.21], [412.34, 189.36], [411.87, 189.36], [411.81, 195.58], [421.62, 195.58], [421.63, 198.79], [421.34, 198.79], [421.34, 197.36], [419.78, 197.36], [419.81, 201.18], [412.0, 201.22], [412.0, 207.34], [420.99, 207.34], [420.99, 201.31], [420.77, 201.31], [420.77, 200.51], [421.34, 200.51], [421.34, 200.43], [421.63, 200.43], [421.63, 200.44], [421.91, 200.44], [421.91, 201.15], [423.2, 201.15], [423.2, 201.35], [421.64, 201.35], [421.64, 207.7], [426.99, 207.72], [426.99, 201.35], [424.95, 201.35], [424.95, 201.15], [426.57, 201.15], [426.57, 200.72], [427.5, 200.72], [427.5, 201.0], [440.17, 201.0], [440.19, 164.3], [396.06, 160.7], [399.94, 124.9], [389.56, 123.88], [386.49, 153.69], [364.71, 151.88], [354.13, 151.04], [343.88, 151.12], [343.89, 157.08], [343.92, 157.08], [343.89, 151.17], [354.19, 151.27], [364.46, 152.22], [363.92, 158.05], [365.09, 158.17], [353.88, 157.25], [343.62, 157.25], [343.62, 150.0], [298.72, 146.28], [276.27, 144.15], [276.32, 143.58], [277.46, 143.69], [278.01, 138.07], [277.6, 142.23], [276.65, 142.16], [277.04, 137.98], [276.65, 142.12], [276.39, 142.09], [276.45, 141.51], [274.05, 141.28], [274.01, 141.78], [273.58, 141.74], [273.6, 141.52], [273.77, 141.54], [273.93, 139.67], [272.17, 139.5], [272.01, 141.37], [272.73, 141.44], [272.71, 141.67], [271.97, 141.6], [271.82, 143.16], [272.82, 143.25], [272.76, 143.82], [271.2, 143.67], [271.7, 139.66], [270.53, 139.55], [270.48, 140.23], [257.45, 139.03], [257.51, 138.35], [253.44, 137.99], [253.37, 138.64], [247.78, 138.13], [248.29, 132.44], [249.0, 132.51], [249.26, 129.73], [242.74, 129.16], [242.76, 129.01], [231.46, 127.99], [231.31, 139.99], [229.09, 144.68], [225.1, 149.11], [218.76, 151.9], [210.52, 151.46], [210.71, 194.43], [215.06, 194.42], [215.06, 191.62], [259.63, 191.62], [259.63, 192.47], [272.66, 192.47], [272.66, 193.31], [272.37, 193.32], [272.37, 192.83], [267.32, 192.84], [267.32, 194.29], [268.93, 194.28], [268.92, 198.23], [268.93, 194.29], [270.36, 194.29], [270.58, 194.29], [270.62, 201.23]], [[293.81, 183.88], [294.19, 184.59], [294.47, 185.63], [294.44, 187.09], [294.0, 188.31], [293.22, 189.28], [291.94, 190.19], [290.22, 190.56], [288.31, 190.09], [287.25, 189.38], [286.38, 188.31], [285.97, 186.72], [285.97, 185.53], [286.22, 184.53], [286.91, 183.5], [287.66, 182.72], [288.63, 182.22], [289.47, 181.97], [291.06, 182.03], [292.03, 182.38], [293.03, 182.94], [293.81, 183.88]], [[274.56, 199.78], [274.56, 199.21], [275.1, 199.19], [275.1, 199.78], [274.56, 199.78]], [[275.07, 203.84], [274.54, 203.84], [274.54, 203.3], [275.07, 203.3], [275.07, 203.84]], [[272.37, 204.1], [272.37, 194.36], [272.66, 194.36], [272.66, 204.1], [272.37, 204.1]], [[269.84, 176.84], [270.18, 177.33], [270.41, 178.03], [270.4, 178.69], [270.29, 179.19], [270.09, 179.56], [269.8, 179.94], [269.47, 180.22], [269.1, 180.43], [268.67, 180.58], [268.2, 180.63], [267.74, 180.58], [267.17, 180.38], [266.69, 180.07], [266.21, 179.48], [266.0, 178.89], [265.94, 178.21], [266.08, 177.7], [266.3, 177.23], [266.62, 176.8], [267.02, 176.47], [267.48, 176.23], [268.26, 176.12], [268.79, 176.21], [269.48, 176.55], [269.84, 176.84]]], [[[343.99, 201.08], [343.29, 201.08], [343.29, 200.65], [343.69, 200.65], [343.69, 200.94], [344.15, 200.94], [344.15, 207.31], [352.44, 207.31], [352.44, 201.31], [345.35, 201.31], [345.35, 197.45], [343.69, 197.45], [343.69, 198.97], [343.29, 198.97], [343.29, 195.59], [350.88, 195.59], [350.88, 188.95], [348.51, 188.95], [348.51, 189.49], [348.25, 189.49], [348.24, 190.57], [348.51, 190.57], [348.51, 190.87], [343.34, 190.87], [343.28, 190.63], [338.78, 190.63], [338.78, 201.08], [338.21, 201.08], [338.21, 207.65], [343.99, 207.64], [343.99, 201.08]]], [[[269.09, 229.5], [272.65, 229.5], [272.65, 225.14], [269.09, 225.14], [269.09, 229.5]]], [[[249.11, 234.45], [249.11, 246.06], [300.43, 246.07], [300.43, 234.45], [249.11, 234.45]]]]}	0.00	2	\N	\N
+226	{"type": "Polygon", "coordinates": [[[269.03, 233.92], [266.97, 233.92], [266.97, 230.31], [269.03, 230.31], [269.03, 231.89], [268.77, 231.89], [268.76, 232.33], [269.03, 232.33], [269.03, 233.92]]]}	2.21	85	\N	\N
+124	{"type": "MultiPolygon", "coordinates": [[[[339.8, 202.68], [339.8, 202.47], [340.31, 202.47], [340.31, 201.23], [338.52, 201.23], [338.52, 202.68], [339.8, 202.68]]], [[[426.91, 202.72], [426.91, 201.31], [425.01, 201.31], [425.01, 202.68], [425.63, 202.68], [425.63, 202.72], [426.91, 202.72]]]]}	5.33	82	\N	\N
+100	{"type": "Polygon", "coordinates": [[[274.51, 213.55], [272.72, 213.55], [272.72, 211.63], [274.5, 211.63], [274.51, 213.55]]]}	-4.50	10	\N	\N
+179	{"type": "Polygon", "coordinates": [[[277.82, 139.94], [277.75, 140.74], [276.8, 140.65], [276.87, 139.85], [277.82, 139.94]]]}	-0.50	11	\N	\N
+175	{"type": "Polygon", "coordinates": [[[274.26, 139.27], [274.29, 138.99], [276.72, 139.22], [276.69, 139.5], [274.26, 139.27]]]}	-2.16	10	\N	\N
+33	{"type": "Polygon", "coordinates": [[[270.36, 197.9], [270.36, 198.2], [268.96, 198.2], [268.96, 197.9], [270.36, 197.9]]]}	-5.07	77	\N	\N
+34	{"type": "Polygon", "coordinates": [[[270.36, 197.3], [270.36, 197.6], [268.96, 197.6], [268.96, 197.3], [270.36, 197.3]]]}	-4.74	77	\N	\N
+37	{"type": "Polygon", "coordinates": [[[270.36, 196.4], [270.36, 196.7], [268.96, 196.7], [268.96, 196.4], [270.36, 196.4]]]}	-4.25	77	\N	\N
+15	{"type": "Polygon", "coordinates": [[[274.81, 183.31], [274.81, 179.37], [274.55, 179.37], [274.55, 179.65], [274.54, 179.65], [274.54, 189.16], [272.22, 189.16], [272.21, 205.58], [270.75, 205.58], [270.75, 204.92], [270.32, 204.92], [270.32, 203.94], [270.74, 203.94], [270.7, 194.23], [270.37, 194.23], [270.37, 194.36], [268.71, 194.37], [268.69, 197.91], [267.38, 197.91], [267.36, 192.56], [270.37, 192.56], [270.37, 192.64], [270.69, 192.64], [270.65, 183.96], [272.76, 183.96], [272.76, 179.67], [272.76, 179.58], [272.76, 179.37], [272.69, 179.37], [272.69, 173.12], [268.0, 173.12], [268.0, 156.12], [269.88, 156.12], [269.88, 153.37], [334.06, 153.37], [334.06, 157.98], [367.13, 157.98], [367.13, 180.44], [350.0, 180.44], [350.0, 183.19], [299.12, 183.19], [299.12, 180.56], [283.56, 180.56], [283.56, 183.31], [274.81, 183.31]]]}	-6.21	34	\N	\N
 273	{"type": "Polygon", "coordinates": [[[284.05, 205.25], [284.05, 203.9], [301.53, 203.9], [301.53, 205.25], [284.05, 205.25]]]}	-2.69	11	\N	\N
 271	{"type": "Polygon", "coordinates": [[[284.05, 202.54], [284.05, 201.19], [301.53, 201.19], [301.53, 202.54], [284.05, 202.54]]]}	-1.92	11	\N	\N
-14	{"type": "Polygon", "coordinates": [[[274.46, 181.71], [272.72, 181.71], [272.72, 185.46], [274.47, 185.46], [274.46, 181.71]]]}	\N	10	\N	[{"altitude": -3.45, "coordinates": [274.463124220837, 181.709]}, {"altitude": -3.45, "coordinates": [274.4631255565449, 181.71]}, {"altitude": -3.45, "coordinates": [272.72, 181.71]}, {"altitude": -3.45, "coordinates": [272.72, 181.709]}, {"altitude": -3.6, "coordinates": [272.87, 185.46]}, {"altitude": -3.6, "coordinates": [274.46813446126447, 185.46]}, {"altitude": -3.6, "coordinates": [274.46813579688467, 185.46099993432932]}, {"altitude": -3.6, "coordinates": [272.71900000000005, 185.46]}, {"altitude": -3.6, "coordinates": [272.72, 185.46]}]
-358	{"type": "MultiPolygon", "coordinates": [[[[248.95, 137.15], [252.63, 137.5], [252.65, 137.21], [249.25, 136.9], [249.58, 133.37], [249.3, 133.35], [248.95, 137.15]]], [[[269.81, 138.8], [258.42, 137.74], [258.4, 138.01], [269.79, 139.07], [269.81, 138.8]]], [[[276.59, 140.15], [274.18, 139.93], [274.15, 140.19], [276.56, 140.42], [276.59, 140.15]]]]}	0.83	2	\N	\N
-145	{"type": "MultiPolygon", "coordinates": [[[[348.27, 188.99], [346.42, 188.99], [346.42, 190.69], [348.27, 190.69], [348.27, 188.99]]], [[[426.91, 203.58], [425.75, 203.58], [425.75, 203.7], [426.91, 203.7], [426.91, 203.58]]], [[[339.8, 203.55], [338.52, 203.55], [338.52, 203.83], [339.8, 203.83], [339.8, 203.55]]], [[[272.73, 231.89], [272.73, 230.31], [272.39, 230.31], [272.39, 231.89], [272.73, 231.89]]]]}	0.00	85	\N	\N
-136	{"type": "MultiPolygon", "coordinates": [[[[339.9, 206.23], [339.8, 206.23], [339.8, 206.13], [338.52, 206.13], [338.52, 207.6], [339.9, 207.6], [339.9, 206.23]]], [[[425.55, 207.68], [426.91, 207.68], [426.91, 206.19], [425.63, 206.19], [425.63, 206.44], [425.55, 206.44], [425.55, 207.68]]]]}	7.43	82	\N	\N
-154	{"type": "MultiPolygon", "coordinates": [[[[339.9, 206.23], [339.8, 206.23], [339.8, 206.13], [338.52, 206.13], [338.52, 207.6], [339.9, 207.6], [339.9, 206.23]]], [[[425.75, 206.4], [425.75, 206.55], [425.71, 206.55], [425.71, 207.68], [426.91, 207.68], [426.91, 206.4], [425.75, 206.4]]]]}	1.83	85	\N	\N
-319	{"type": "Polygon", "coordinates": [[[248.98, 132.78], [248.95, 133.05], [248.93, 133.31], [249.58, 133.37], [249.25, 136.9], [252.65, 137.21], [252.6, 137.91], [252.91, 137.94], [253.18, 137.96], [253.44, 137.99], [257.51, 138.35], [257.77, 138.38], [258.05, 138.4], [258.37, 138.43], [258.42, 137.74], [269.81, 138.8], [269.75, 139.48], [269.98, 139.5], [270.26, 139.53], [270.53, 139.55], [271.7, 139.66], [271.72, 139.44], [271.74, 139.24], [271.87, 138.0], [267.04, 137.54], [267.11, 136.59], [272.35, 137.07], [273.26, 127.01], [272.34, 137.49], [273.55, 137.6], [273.54, 137.7], [272.35, 137.59], [272.17, 139.25], [274.22, 139.46], [274.18, 139.93], [276.59, 140.15], [276.8, 138.01], [276.29, 137.96], [276.29, 137.85], [278.73, 138.08], [278.78, 137.51], [278.88, 137.51], [278.8, 138.32], [278.45, 138.26], [277.93, 143.73], [298.3, 145.79], [300.23, 125.07], [280.22, 123.24], [279.93, 126.35], [279.8, 126.34], [280.09, 123.21], [278.08, 123.02], [278.29, 120.53], [277.97, 120.5], [277.98, 120.4], [279.71, 120.55], [280.1, 116.13], [277.53, 115.88], [277.11, 120.32], [277.19, 120.33], [277.18, 120.43], [276.83, 120.4], [276.85, 120.29], [276.97, 120.3], [277.36, 115.87], [274.35, 115.6], [273.92, 120.01], [276.07, 120.21], [276.06, 120.34], [275.97, 120.33], [275.97, 120.38], [275.85, 120.36], [275.85, 120.31], [273.93, 120.14], [273.72, 122.27], [275.64, 122.43], [275.71, 121.77], [275.82, 121.78], [275.72, 122.77], [273.65, 122.59], [273.65, 122.61], [265.19, 121.84], [264.98, 123.97], [254.68, 122.99], [253.85, 123.36], [253.29, 123.74], [252.79, 124.22], [252.34, 124.92], [251.29, 135.14], [261.95, 136.12], [261.87, 137.05], [259.39, 136.82], [250.34, 135.98], [250.34, 135.97], [250.26, 135.96], [250.88, 129.87], [249.67, 129.76], [249.68, 129.64], [249.27, 129.6], [249.0, 132.51], [248.98, 132.78]], [[271.74, 139.24], [270.56, 139.13], [270.57, 139.13], [271.74, 139.24]], [[270.56, 139.13], [270.3, 139.11], [270.21, 139.1], [270.56, 139.13]], [[249.64, 133.38], [249.66, 133.09], [249.67, 132.96], [249.64, 133.38]], [[295.29, 130.8], [297.19, 130.99], [297.16, 131.32], [295.26, 131.15], [295.29, 130.8]], [[295.67, 136.63], [296.01, 136.66], [295.99, 137.0], [295.63, 136.96], [295.67, 136.63]], [[295.36, 139.99], [295.39, 139.65], [295.73, 139.68], [295.7, 140.02], [295.36, 139.99]], [[289.43, 130.26], [291.34, 130.45], [291.31, 130.79], [289.4, 130.61], [289.43, 130.26]], [[289.76, 136.09], [290.1, 136.12], [290.07, 136.45], [289.73, 136.42], [289.76, 136.09]], [[289.45, 139.44], [289.48, 139.11], [289.83, 139.14], [289.8, 139.48], [289.45, 139.44]], [[283.56, 129.74], [285.47, 129.89], [285.43, 130.25], [283.53, 130.08], [283.56, 129.74]], [[283.91, 135.54], [284.27, 135.58], [284.23, 135.92], [283.88, 135.89], [283.91, 135.54]], [[283.62, 138.56], [283.99, 138.59], [283.95, 138.95], [283.59, 138.91], [283.62, 138.56]], [[279.08, 134.26], [279.5, 129.7], [277.69, 129.53], [277.76, 128.27], [279.62, 128.37], [279.67, 127.78], [279.79, 127.79], [279.01, 136.06], [278.92, 136.05], [278.97, 135.42], [277.16, 135.26], [277.27, 134.14], [279.08, 134.26]], [[271.03, 127.98], [272.81, 128.11], [272.71, 129.05], [270.93, 128.9], [271.03, 127.98]], [[270.5, 133.56], [272.32, 133.69], [272.23, 134.62], [270.45, 134.46], [270.5, 133.56]], [[267.49, 127.31], [268.85, 127.44], [268.81, 127.78], [267.48, 127.67], [267.49, 127.31]], [[266.86, 134.14], [268.22, 134.26], [268.16, 134.6], [266.82, 134.49], [266.86, 134.14]], [[264.1, 136.31], [265.24, 136.42], [265.16, 137.36], [264.05, 137.26], [264.1, 136.31]], [[263.38, 126.93], [264.74, 127.02], [264.71, 127.42], [263.35, 127.27], [263.38, 126.93]], [[262.73, 133.74], [264.11, 133.86], [264.07, 134.24], [262.7, 134.11], [262.73, 133.74]], [[260.5, 127.0], [259.35, 126.91], [259.25, 127.87], [258.86, 127.82], [259.01, 126.51], [260.54, 126.65], [260.5, 127.0]], [[259.89, 133.51], [259.85, 133.84], [258.32, 133.7], [258.46, 132.42], [258.85, 132.46], [258.74, 133.37], [259.89, 133.51]], [[253.0, 137.17], [253.08, 137.18], [252.66, 137.14], [253.0, 137.17]], [[253.08, 137.18], [253.05, 137.53], [253.07, 137.24], [253.08, 137.18]], [[253.05, 137.53], [256.28, 137.82], [253.48, 137.57], [253.22, 137.55], [253.05, 137.53]]]}	1.00	2	\N	\N
-266	{"type": "Polygon", "coordinates": [[[272.43, 203.64], [272.43, 205.89], [270.62, 205.89], [270.62, 203.47], [266.91, 203.47], [266.91, 206.15], [267.12, 206.15], [267.12, 206.09], [270.3, 206.08], [270.3, 208.68], [266.9, 208.67], [266.89, 207.16], [267.11, 207.16], [267.11, 206.94], [266.91, 206.94], [266.91, 207.0], [265.93, 207.01], [265.93, 207.17], [266.72, 207.17], [266.72, 208.66], [264.39, 208.67], [264.39, 207.17], [265.23, 207.17], [265.23, 207.02], [263.85, 207.03], [263.85, 206.84], [263.73, 206.84], [263.73, 207.11], [264.21, 207.11], [264.21, 208.69], [260.14, 208.71], [260.14, 206.1], [263.73, 206.1], [263.73, 206.2], [263.85, 206.2], [263.82, 201.33], [270.54, 201.3], [270.54, 199.69], [272.71, 199.69], [272.71, 199.25], [274.47, 199.25], [274.47, 212.02], [274.66, 212.02], [274.66, 222.42], [274.53, 222.42], [274.53, 229.98], [283.48, 229.98], [283.48, 230.83], [283.95, 230.83], [283.95, 230.23], [285.79, 230.23], [285.79, 231.93], [283.95, 231.93], [283.95, 231.61], [283.48, 231.61], [283.48, 232.66], [283.95, 232.66], [283.95, 232.3], [285.79, 232.3], [285.79, 234.0], [283.95, 234.0], [283.95, 233.44], [283.48, 233.44], [283.48, 233.99], [272.62, 233.99], [272.62, 232.17], [268.76, 232.17], [268.76, 233.94], [266.97, 233.94], [266.97, 230.34], [272.63, 230.34], [272.7, 203.64], [272.43, 203.64]]]}	9.25	38	\N	\N
-267	{"type": "MultiPolygon", "coordinates": [[[[285.79, 230.23], [283.95, 230.23], [283.95, 230.86], [283.59, 230.86], [283.57, 231.59], [283.95, 231.59], [283.95, 231.93], [285.79, 231.93], [285.79, 230.23]]], [[[285.79, 232.3], [283.95, 232.3], [283.95, 232.7], [283.56, 232.7], [283.55, 233.45], [283.95, 233.45], [283.95, 234.0], [285.79, 234.0], [285.79, 232.3]]]]}	6.75	82	\N	\N
-99	{"type": "Polygon", "coordinates": [[[274.49, 201.83], [275.07, 201.79], [275.08, 199.68], [277.41, 199.69], [277.41, 202.88], [277.65, 202.88], [277.65, 199.72], [283.42, 199.72], [283.41, 204.08], [277.65, 204.08], [277.65, 203.72], [277.41, 203.72], [277.41, 204.68], [277.63, 204.68], [277.63, 204.33], [283.48, 204.37], [283.48, 209.09], [277.63, 209.09], [277.63, 205.57], [277.41, 205.57], [277.41, 206.11], [276.23, 206.1], [276.23, 206.31], [277.44, 206.32], [277.44, 209.11], [275.1, 209.11], [275.1, 206.31], [275.34, 206.31], [275.34, 206.09], [275.12, 206.09], [275.11, 203.2], [274.5, 203.23], [274.5, 204.02], [272.72, 204.02], [272.72, 201.56], [274.49, 201.56], [274.49, 201.83]]]}	-4.10	10	\N	\N
 268	{"type": "Polygon", "coordinates": [[[284.05, 197.12], [284.05, 195.77], [301.53, 195.77], [301.53, 197.12], [284.05, 197.12]]]}	-0.38	11	\N	\N
-78	{"type": "Polygon", "coordinates": [[[270.36, 198.2], [270.36, 199.3], [267.44, 199.29], [267.43, 198.2], [268.71, 198.2], [268.71, 198.23], [268.93, 198.23], [268.93, 198.2], [270.36, 198.2]]]}	-2.29	11	\N	\N
-342	{"type": "MultiPolygon", "coordinates": [[[[285.79, 231.93], [285.79, 230.23], [283.95, 230.23], [283.95, 231.93], [285.79, 231.93]]], [[[283.95, 232.3], [283.95, 234.0], [285.79, 234.0], [285.79, 232.3], [283.95, 232.3]]]]}	2.10	85	\N	\N
-179	{"type": "Polygon", "coordinates": [[[277.82, 139.94], [277.75, 140.74], [276.8, 140.65], [276.87, 139.85], [277.82, 139.94]]]}	-0.50	11	\N	\N
-270	{"type": "Polygon", "coordinates": [[[284.05, 201.19], [284.05, 199.83], [301.53, 199.83], [301.53, 201.19], [284.05, 201.19]]]}	-1.54	11	\N	\N
-181	{"type": "Polygon", "coordinates": [[[277.0, 138.49], [277.05, 137.98], [278.0, 138.08], [277.95, 138.59], [277.0, 138.49]]]}	-2.00	11	\N	\N
-188	{"type": "MultiPolygon", "coordinates": [[[[284.05, 212.02], [284.05, 212.09], [301.53, 212.09], [301.53, 212.02], [284.05, 212.02]]], [[[272.39, 231.89], [272.73, 231.89], [272.73, 230.31], [272.39, 230.31], [272.39, 231.89]]]]}	-5.00	11	\N	\N
-362	{"type": "Polygon", "coordinates": [[[272.37, 206.15], [272.37, 206.46], [270.64, 206.46], [270.64, 206.15], [272.37, 206.15]]]}	0.15	2	\N	\N
-104	{"type": "MultiPolygon", "coordinates": [[[[272.17, 139.27], [272.01, 140.98], [273.77, 141.14], [273.94, 139.44], [272.17, 139.27]]], [[[350.82, 156.73], [353.91, 157.02], [364.32, 158.05], [364.86, 152.13], [354.29, 151.1], [351.13, 151.08], [343.15, 151.04], [341.79, 151.23], [340.49, 151.57], [339.46, 152.06], [338.54, 152.56], [336.83, 153.94], [335.8, 155.2], [335.2, 156.29], [334.55, 157.98], [341.05, 157.98], [341.05, 157.78], [342.07, 157.07], [343.12, 156.77], [350.82, 156.73]]], [[[267.36, 203.59], [267.36, 205.58], [270.36, 205.58], [270.36, 203.59], [267.36, 203.59]]], [[[283.95, 231.93], [285.79, 231.93], [285.79, 230.23], [283.95, 230.23], [283.95, 231.93]]], [[[285.79, 232.3], [283.95, 232.3], [283.95, 234.0], [285.79, 234.0], [285.79, 232.3]]]]}	-3.00	11	\N	\N
-92	{"type": "MultiPolygon", "coordinates": [[[[268.93, 196.1], [268.93, 196.4], [270.36, 196.4], [270.36, 196.1], [268.93, 196.1]]], [[[301.53, 199.83], [301.53, 198.48], [284.05, 198.48], [284.05, 199.83], [301.53, 199.83]], [[299.83, 199.75], [299.83, 199.24], [300.36, 199.24], [300.36, 199.75], [299.83, 199.75]], [[286.35, 199.25], [289.48, 199.25], [289.48, 199.75], [286.35, 199.75], [286.35, 199.25]]]]}	-1.15	11	\N	\N
-275	{"type": "Polygon", "coordinates": [[[284.05, 207.96], [284.05, 206.6], [301.53, 206.6], [301.53, 207.96], [284.05, 207.96]], [[300.36, 207.91], [300.36, 207.4], [299.83, 207.4], [299.83, 207.91], [300.36, 207.91]], [[286.35, 207.91], [289.5, 207.91], [289.49, 207.41], [286.35, 207.41], [286.35, 207.91]]]}	-3.46	11	\N	\N
-32	{"type": "Polygon", "coordinates": [[[267.43, 197.9], [267.43, 197.6], [268.69, 197.6], [268.69, 197.9], [267.43, 197.9]]]}	-5.39	77	\N	\N
-16	{"type": "Polygon", "coordinates": [[[267.42, 196.4], [267.42, 196.11], [268.69, 196.11], [268.69, 196.4], [267.42, 196.4]]]}	-6.21	77	\N	\N
-15	{"type": "Polygon", "coordinates": [[[269.88, 156.12], [269.88, 153.37], [334.06, 153.37], [334.06, 157.98], [367.13, 157.98], [367.13, 180.44], [350.0, 180.44], [350.0, 183.19], [299.12, 183.19], [299.12, 180.56], [283.56, 180.56], [283.56, 183.31], [274.81, 183.31], [274.81, 179.37], [274.55, 179.37], [274.55, 179.65], [274.54, 179.65], [274.54, 189.16], [272.22, 189.16], [272.21, 205.58], [270.75, 205.58], [270.75, 204.92], [270.32, 204.92], [270.32, 203.94], [270.74, 203.94], [270.7, 194.23], [270.37, 194.23], [270.37, 194.36], [268.71, 194.37], [268.69, 197.91], [267.38, 197.91], [267.36, 192.56], [270.37, 192.56], [270.37, 192.64], [270.69, 192.64], [270.65, 183.96], [272.76, 183.96], [272.76, 179.67], [272.76, 179.58], [272.76, 179.37], [272.69, 179.37], [272.69, 173.12], [268.0, 173.12], [268.0, 156.12], [269.88, 156.12]]]}	-6.21	34	\N	\N
-21	{"type": "MultiPolygon", "coordinates": [[[[341.05, 157.78], [342.07, 157.07], [343.12, 156.77], [350.82, 156.73], [353.91, 157.02], [354.92, 157.34], [355.44, 157.62], [355.84, 157.94], [355.84, 158.02], [362.3, 158.03], [361.84, 156.82], [361.26, 155.68], [360.56, 154.73], [359.63, 153.73], [358.53, 152.9], [357.19, 152.16], [355.89, 151.67], [354.83, 151.42], [351.13, 151.08], [343.14, 151.06], [341.79, 151.23], [340.49, 151.57], [339.46, 152.06], [338.54, 152.56], [336.83, 153.94], [335.8, 155.2], [335.2, 156.29], [334.55, 157.98], [341.05, 157.98], [341.05, 157.78]]], [[[268.96, 197.9], [270.36, 197.9], [270.36, 197.6], [268.96, 197.6], [268.96, 197.9]]], [[[270.36, 203.59], [267.36, 203.59], [267.36, 205.58], [270.36, 205.58], [270.36, 203.59]]]]}	-4.90	77	\N	\N
-82	{"type": "Polygon", "coordinates": [[[268.7, 197.0], [268.71, 197.3], [267.43, 197.3], [267.43, 197.0], [268.7, 197.0]]]}	-2.95	11	\N	\N
-4	{"type": "MultiPolygon", "coordinates": [[[[200.53, 115.55], [200.48, 114.05], [198.82, 114.05], [198.77, 115.5], [200.53, 115.55]]], [[[270.36, 198.24], [270.36, 198.23], [268.92, 198.23], [270.36, 198.24]]], [[[343.92, 157.08], [353.88, 157.08], [362.27, 157.89], [353.97, 157.05], [343.92, 157.08]]], [[[270.62, 201.23], [269.47, 201.23], [269.47, 201.24], [269.44, 201.24], [269.44, 201.23], [251.96, 201.23], [251.96, 200.52], [259.45, 200.52], [259.42, 192.41], [240.04, 192.41], [240.04, 200.52], [250.47, 200.52], [250.46, 201.23], [239.73, 201.23], [239.73, 198.92], [235.34, 198.92], [235.34, 201.25], [215.82, 201.25], [215.82, 203.44], [235.53, 203.44], [235.53, 203.75], [239.58, 203.75], [239.59, 205.04], [239.59, 203.39], [263.91, 203.39], [263.91, 206.18], [263.73, 206.18], [263.73, 206.1], [260.14, 206.1], [260.14, 208.71], [264.21, 208.69], [264.21, 207.11], [263.73, 207.11], [263.73, 206.9], [263.91, 206.9], [263.91, 206.91], [265.21, 206.91], [265.21, 207.17], [264.39, 207.17], [264.39, 208.67], [266.72, 208.66], [266.72, 207.17], [265.95, 207.17], [265.95, 206.91], [266.94, 206.91], [266.94, 206.89], [267.11, 206.89], [267.11, 207.16], [266.89, 207.16], [266.9, 208.67], [270.3, 208.68], [270.3, 206.08], [267.12, 206.09], [267.12, 206.1], [266.94, 206.1], [266.94, 203.47], [269.44, 203.47], [269.44, 203.46], [269.46, 203.46], [269.46, 203.47], [270.63, 203.47], [270.63, 204.15], [270.4, 204.15], [270.4, 203.71], [267.26, 203.71], [267.26, 205.83], [270.4, 205.8], [270.4, 205.08], [270.64, 205.08], [270.64, 206.15], [272.37, 206.15], [272.37, 205.42], [272.66, 205.42], [272.66, 207.36], [274.5, 207.36], [274.5, 207.3], [274.99, 207.3], [274.99, 205.44], [275.11, 205.44], [275.11, 205.42], [283.42, 205.42], [283.42, 194.36], [283.68, 194.36], [283.68, 194.29], [272.7, 194.29], [272.7, 194.23], [302.38, 194.13], [302.41, 200.83], [337.54, 200.75], [337.54, 185.02], [352.38, 185.02], [352.38, 180.37], [422.1, 180.52], [422.1, 184.79], [427.34, 184.8], [427.48, 198.98], [426.57, 198.98], [426.56, 190.86], [414.02, 190.85], [414.03, 189.37], [413.95, 189.37], [413.95, 189.21], [414.01, 189.21], [414.01, 186.02], [411.86, 186.02], [411.86, 189.21], [412.34, 189.21], [412.34, 189.36], [411.87, 189.36], [411.81, 195.58], [421.62, 195.58], [421.63, 198.79], [421.34, 198.79], [421.34, 197.36], [419.78, 197.36], [419.81, 201.18], [412.0, 201.22], [412.0, 207.34], [420.99, 207.34], [420.99, 201.31], [420.77, 201.31], [420.77, 200.51], [421.34, 200.51], [421.34, 200.43], [421.63, 200.43], [421.63, 200.44], [421.91, 200.44], [421.91, 201.15], [423.2, 201.15], [423.2, 201.35], [421.64, 201.35], [421.64, 207.7], [426.99, 207.72], [426.99, 201.35], [424.95, 201.35], [424.95, 201.15], [426.57, 201.15], [426.57, 200.72], [427.5, 200.72], [427.5, 201.0], [440.17, 201.0], [440.19, 164.3], [396.06, 160.7], [399.94, 124.9], [389.56, 123.88], [386.49, 153.69], [364.71, 151.88], [354.13, 151.04], [343.88, 151.12], [343.89, 157.08], [343.92, 157.08], [343.89, 151.17], [354.19, 151.27], [364.46, 152.22], [363.92, 158.05], [365.09, 158.17], [353.88, 157.25], [343.62, 157.25], [343.62, 150.0], [298.72, 146.28], [276.27, 144.15], [276.32, 143.58], [277.46, 143.69], [278.01, 138.07], [277.6, 142.23], [276.65, 142.16], [277.04, 137.98], [276.65, 142.12], [276.39, 142.09], [276.45, 141.51], [274.05, 141.28], [274.01, 141.78], [273.58, 141.74], [273.6, 141.52], [273.77, 141.54], [273.93, 139.67], [272.17, 139.5], [272.01, 141.37], [272.73, 141.44], [272.71, 141.67], [271.97, 141.6], [271.82, 143.16], [272.82, 143.25], [272.76, 143.82], [271.2, 143.67], [271.7, 139.66], [270.53, 139.55], [270.48, 140.23], [257.45, 139.03], [257.51, 138.35], [253.44, 137.99], [253.37, 138.64], [247.78, 138.13], [248.29, 132.44], [249.0, 132.51], [249.26, 129.73], [242.74, 129.16], [242.76, 129.01], [231.46, 127.99], [231.31, 139.99], [229.09, 144.68], [225.1, 149.11], [218.76, 151.9], [210.52, 151.46], [210.71, 194.43], [215.06, 194.42], [215.06, 191.62], [259.63, 191.62], [259.63, 192.47], [272.66, 192.47], [272.66, 193.31], [272.37, 193.32], [272.37, 192.83], [267.32, 192.84], [267.32, 194.29], [268.93, 194.28], [268.92, 198.23], [268.93, 194.29], [270.36, 194.29], [270.58, 194.29], [270.62, 201.23]], [[294.19, 184.59], [294.47, 185.63], [294.44, 187.09], [294.0, 188.31], [293.22, 189.28], [291.94, 190.19], [290.22, 190.56], [288.31, 190.09], [287.25, 189.38], [286.38, 188.31], [285.97, 186.72], [285.97, 185.53], [286.22, 184.53], [286.91, 183.5], [287.66, 182.72], [288.63, 182.22], [289.47, 181.97], [291.06, 182.03], [292.03, 182.38], [293.03, 182.94], [293.81, 183.88], [294.19, 184.59]], [[274.56, 199.78], [274.56, 199.21], [275.1, 199.19], [275.1, 199.78], [274.56, 199.78]], [[275.07, 203.84], [274.54, 203.84], [274.54, 203.3], [275.07, 203.3], [275.07, 203.84]], [[272.37, 204.1], [272.37, 194.36], [272.66, 194.36], [272.66, 204.1], [272.37, 204.1]], [[270.18, 177.33], [270.41, 178.03], [270.4, 178.69], [270.29, 179.19], [270.09, 179.56], [269.8, 179.94], [269.47, 180.22], [269.1, 180.43], [268.67, 180.58], [268.2, 180.63], [267.74, 180.58], [267.17, 180.38], [266.69, 180.07], [266.21, 179.48], [266.0, 178.89], [265.94, 178.21], [266.08, 177.7], [266.3, 177.23], [266.62, 176.8], [267.02, 176.47], [267.48, 176.23], [268.26, 176.12], [268.79, 176.21], [269.48, 176.55], [269.84, 176.84], [270.18, 177.33]]], [[[343.99, 201.08], [343.29, 201.08], [343.29, 200.65], [343.69, 200.65], [343.69, 200.94], [344.15, 200.94], [344.15, 207.31], [352.44, 207.31], [352.44, 201.31], [345.35, 201.31], [345.35, 197.45], [343.69, 197.45], [343.69, 198.97], [343.29, 198.97], [343.29, 195.59], [350.88, 195.59], [350.88, 188.95], [348.51, 188.95], [348.51, 189.49], [348.25, 189.49], [348.24, 190.57], [348.51, 190.57], [348.51, 190.87], [343.34, 190.87], [343.28, 190.63], [338.78, 190.63], [338.78, 201.08], [338.21, 201.08], [338.21, 207.65], [343.99, 207.64], [343.99, 201.08]]], [[[272.65, 225.14], [269.09, 225.14], [269.09, 229.5], [272.65, 229.5], [272.65, 225.14]]], [[[300.43, 246.07], [300.43, 234.45], [249.11, 234.45], [249.11, 246.06], [300.43, 246.07]]]]}	0.00	2	\N	\N
-70	{"type": "MultiPolygon", "coordinates": [[[[276.75, 141.18], [277.7, 141.28], [277.72, 141.02], [276.77, 140.92], [276.75, 141.18]]], [[[270.36, 194.09], [268.93, 194.09], [268.93, 194.3], [270.36, 194.3], [270.36, 194.09]]], [[[301.53, 194.38], [284.05, 194.38], [284.05, 195.77], [301.53, 195.77], [301.53, 194.38]]], [[[272.74, 233.92], [272.73, 232.33], [272.67, 232.33], [272.67, 233.92], [272.74, 233.92]]]]}	0.00	11	\N	\N
-274	{"type": "Polygon", "coordinates": [[[284.05, 206.6], [284.05, 205.25], [301.53, 205.25], [301.53, 206.6], [284.05, 206.6]]]}	-3.08	11	\N	\N
-278	{"type": "Polygon", "coordinates": [[[284.05, 212.02], [284.05, 210.67], [301.53, 210.67], [301.53, 212.02], [284.05, 212.02]], [[300.36, 211.97], [300.36, 211.46], [299.83, 211.46], [299.83, 211.97], [300.36, 211.97]], [[286.34, 211.97], [289.49, 211.97], [289.5, 211.47], [286.34, 211.47], [286.34, 211.97]]]}	-4.62	11	\N	\N
-123	{"type": "MultiPolygon", "coordinates": [[[[341.8, 207.6], [342.12, 207.6], [342.12, 206.24], [341.8, 206.24], [341.8, 207.6]]], [[[423.64, 207.68], [423.64, 206.43], [423.33, 206.43], [423.33, 207.68], [423.64, 207.68]]], [[[271.55, 232.33], [271.55, 233.92], [271.83, 233.92], [271.83, 232.33], [271.55, 232.33]]]]}	8.56	82	\N	\N
-30	{"type": "Polygon", "coordinates": [[[267.43, 197.3], [267.43, 197.0], [268.69, 197.0], [268.69, 197.3], [267.43, 197.3]]]}	-5.72	77	\N	\N
+2	{"type": "Polygon", "coordinates": [[[276.49, 141.47], [276.48, 141.59], [276.49, 141.59], [276.35, 143.25], [273.93, 143.04], [273.21, 150.85], [270.11, 150.87], [270.12, 153.04], [269.81, 153.04], [269.81, 155.98], [269.78, 155.98], [269.78, 156.12], [269.88, 156.12], [269.88, 153.37], [334.06, 153.37], [334.06, 158.0], [367.13, 158.06], [367.13, 180.44], [350.0, 180.44], [350.0, 183.19], [299.12, 183.19], [299.12, 180.56], [283.56, 180.56], [283.56, 183.31], [274.81, 183.31], [274.81, 179.37], [274.46, 179.37], [274.46, 181.71], [272.72, 181.71], [272.72, 179.37], [272.69, 179.37], [272.69, 173.12], [268.0, 173.12], [268.0, 156.12], [268.02, 156.12], [268.03, 155.99], [268.01, 155.99], [267.97, 149.0], [271.18, 148.99], [271.9, 141.19], [274.02, 141.37], [274.04, 141.24], [276.49, 141.47]]]}	-3.45	10	\N	\N
+280	{"type": "MultiPolygon", "coordinates": [[[[270.64, 207.07], [270.66, 211.77], [270.68, 211.77], [270.68, 211.96], [239.59, 211.96], [239.59, 211.59], [239.59, 211.53], [239.59, 211.51], [235.53, 211.5], [235.53, 211.57], [235.54, 211.57], [235.54, 211.96], [205.64, 211.96], [205.64, 223.14], [268.38, 223.22], [268.38, 223.58], [259.65, 223.58], [259.65, 224.91], [260.82, 224.91], [260.82, 225.12], [259.82, 225.12], [259.85, 226.99], [262.01, 226.99], [262.01, 225.12], [261.93, 225.12], [261.93, 224.91], [263.6, 224.91], [263.6, 225.16], [263.44, 225.16], [263.44, 229.52], [265.89, 229.52], [265.89, 225.16], [264.48, 225.16], [264.48, 224.91], [267.63, 224.91], [267.63, 225.16], [266.27, 225.17], [266.26, 229.52], [268.74, 229.52], [268.72, 225.16], [268.57, 225.16], [268.57, 224.91], [271.86, 224.91], [271.86, 223.58], [270.2, 223.58], [270.2, 223.22], [272.22, 223.22], [272.22, 211.96], [272.15, 211.96], [272.15, 211.77], [272.37, 211.77], [272.37, 207.07], [270.64, 207.07]]], [[[272.66, 211.99], [272.66, 222.0], [277.48, 222.0], [277.48, 222.45], [272.73, 222.44], [272.75, 223.59], [271.96, 223.61], [271.92, 224.88], [272.73, 224.88], [272.73, 234.31], [283.53, 234.31], [283.53, 233.45], [284.05, 233.45], [284.05, 232.57], [283.53, 232.57], [283.53, 231.57], [284.03, 231.57], [284.03, 230.76], [283.53, 230.76], [283.53, 229.81], [300.46, 229.81], [300.46, 227.62], [302.65, 227.57], [302.59, 224.95], [300.46, 224.9], [300.46, 222.51], [281.13, 222.46], [281.13, 222.0], [283.42, 222.0], [283.42, 219.95], [275.11, 219.93], [274.99, 219.93], [274.99, 212.03], [274.54, 212.03], [274.54, 211.98], [272.66, 211.99]], [[279.35, 222.46], [279.17, 222.46], [279.17, 222.0], [279.35, 222.0], [279.35, 222.46]]]]}	0.60	2	\N	\N
+341	{"type": "Polygon", "coordinates": [[[411.86, 189.21], [411.86, 186.02], [414.01, 186.02], [414.01, 189.21], [413.9, 189.21], [413.9, 189.46], [414.01, 189.46], [414.01, 190.8], [427.24, 190.83], [427.24, 195.42], [426.53, 195.42], [426.54, 197.11], [426.39, 197.11], [426.39, 197.3], [427.08, 197.3], [427.08, 202.42], [422.86, 202.42], [422.8, 203.16], [422.1, 203.22], [422.08, 205.35], [422.82, 205.38], [422.85, 207.52], [422.38, 207.52], [422.38, 207.2], [403.68, 207.16], [403.54, 197.3], [422.17, 197.3], [422.17, 197.1], [422.14, 195.49], [343.48, 195.47], [343.46, 197.08], [343.47, 197.08], [343.47, 197.25], [360.03, 197.25], [360.03, 207.2], [343.83, 207.2], [343.83, 207.55], [342.82, 207.55], [342.83, 205.37], [343.57, 205.37], [343.57, 203.22], [342.78, 203.22], [342.78, 202.5], [338.62, 202.5], [338.62, 197.45], [338.99, 197.45], [338.99, 197.25], [339.29, 197.25], [339.29, 197.11], [339.26, 190.78], [349.83, 190.78], [349.83, 190.64], [348.54, 190.64], [348.54, 190.59], [348.27, 190.59], [348.27, 190.69], [346.42, 190.69], [346.42, 188.99], [348.27, 188.99], [348.27, 189.54], [348.54, 189.54], [348.54, 189.04], [350.58, 189.04], [350.56, 190.78], [411.87, 190.78], [411.87, 189.46], [412.37, 189.46], [412.37, 189.21], [411.86, 189.21]], [[341.71, 197.11], [341.06, 197.11], [341.06, 197.25], [341.71, 197.25], [341.71, 197.11]], [[424.73, 197.3], [424.73, 197.11], [423.95, 197.1], [423.95, 197.3], [424.73, 197.3]]]}	9.05	38	\N	\N
+266	{"type": "Polygon", "coordinates": [[[264.39, 207.17], [265.23, 207.17], [265.23, 207.02], [263.85, 207.03], [263.85, 206.84], [263.73, 206.84], [263.73, 207.11], [264.21, 207.11], [264.21, 208.69], [260.14, 208.71], [260.14, 206.1], [263.73, 206.1], [263.73, 206.2], [263.85, 206.2], [263.82, 201.33], [270.54, 201.3], [270.54, 199.69], [272.71, 199.69], [272.71, 199.25], [274.47, 199.25], [274.47, 212.02], [274.66, 212.02], [274.66, 222.42], [274.53, 222.42], [274.53, 229.98], [283.48, 229.98], [283.48, 230.83], [283.95, 230.83], [283.95, 230.23], [285.79, 230.23], [285.79, 231.93], [283.95, 231.93], [283.95, 231.61], [283.48, 231.61], [283.48, 232.66], [283.95, 232.66], [283.95, 232.3], [285.79, 232.3], [285.79, 234.0], [283.95, 234.0], [283.95, 233.44], [283.48, 233.44], [283.48, 233.99], [272.62, 233.99], [272.62, 232.17], [268.76, 232.17], [268.76, 233.94], [266.97, 233.94], [266.97, 230.34], [272.63, 230.34], [272.7, 203.64], [272.43, 203.64], [272.43, 205.89], [270.62, 205.89], [270.62, 203.47], [266.91, 203.47], [266.91, 206.15], [267.12, 206.15], [267.12, 206.09], [270.3, 206.08], [270.3, 208.68], [266.9, 208.67], [266.89, 207.16], [267.11, 207.16], [267.11, 206.94], [266.91, 206.94], [266.91, 207.0], [265.93, 207.01], [265.93, 207.17], [266.72, 207.17], [266.72, 208.66], [264.39, 208.67], [264.39, 207.17]]]}	9.25	38	\N	\N
+104	{"type": "MultiPolygon", "coordinates": [[[[273.77, 141.14], [273.94, 139.44], [272.17, 139.27], [272.01, 140.98], [273.77, 141.14]]], [[[342.07, 157.07], [343.12, 156.77], [350.82, 156.73], [353.91, 157.02], [364.32, 158.05], [364.86, 152.13], [354.29, 151.1], [351.13, 151.08], [343.15, 151.04], [341.79, 151.23], [340.49, 151.57], [339.46, 152.06], [338.54, 152.56], [336.83, 153.94], [335.8, 155.2], [335.2, 156.29], [334.55, 157.98], [341.05, 157.98], [341.05, 157.78], [342.07, 157.07]]], [[[270.36, 205.58], [270.36, 203.59], [267.36, 203.59], [267.36, 205.58], [270.36, 205.58]]], [[[285.79, 230.23], [283.95, 230.23], [283.95, 231.93], [285.79, 231.93], [285.79, 230.23]]], [[[283.95, 234.0], [285.79, 234.0], [285.79, 232.3], [283.95, 232.3], [283.95, 234.0]]]]}	-3.00	11	\N	\N
+21	{"type": "MultiPolygon", "coordinates": [[[[334.55, 157.98], [341.05, 157.98], [341.05, 157.78], [342.07, 157.07], [343.12, 156.77], [350.82, 156.73], [353.91, 157.02], [354.92, 157.34], [355.44, 157.62], [355.84, 157.94], [355.84, 158.02], [362.3, 158.03], [361.84, 156.82], [361.26, 155.68], [360.56, 154.73], [359.63, 153.73], [358.53, 152.9], [357.19, 152.16], [355.89, 151.67], [354.83, 151.42], [351.13, 151.08], [343.14, 151.06], [341.79, 151.23], [340.49, 151.57], [339.46, 152.06], [338.54, 152.56], [336.83, 153.94], [335.8, 155.2], [335.2, 156.29], [334.55, 157.98]]], [[[268.96, 197.9], [270.36, 197.9], [270.36, 197.6], [268.96, 197.6], [268.96, 197.9]]], [[[267.36, 205.58], [270.36, 205.58], [270.36, 203.59], [267.36, 203.59], [267.36, 205.58]]]]}	-4.90	77	\N	\N
+241	{"type": "Polygon", "coordinates": [[[272.39, 230.31], [272.73, 230.31], [272.73, 231.89], [272.39, 231.89], [272.39, 230.31]]]}	4.60	82	\N	\N
+364	{"type": "Polygon", "coordinates": [[[274.99, 207.93], [275.11, 207.93], [275.11, 211.43], [274.99, 211.43], [274.99, 211.71], [274.99, 211.98], [274.99, 219.93], [275.11, 219.93], [283.42, 219.95], [283.42, 222.0], [283.68, 222.0], [283.68, 219.95], [283.68, 205.42], [283.68, 194.36], [283.42, 194.36], [283.42, 205.42], [275.11, 205.42], [275.11, 205.44], [274.99, 205.44], [274.99, 207.36], [274.99, 207.65], [274.99, 207.93]], [[275.13, 211.71], [275.13, 211.43], [275.13, 211.37], [275.16, 211.37], [275.16, 212.03], [275.13, 212.03], [275.13, 211.98], [275.13, 211.71]]]}	\N	2	\N	[{"altitude": 0.6, "coordinates": [275.10900005786385, 219.93]}, {"altitude": 0.6, "coordinates": [275.11, 219.93]}, {"altitude": 0.6, "coordinates": [283.42, 219.94983293556083]}, {"altitude": 0.6, "coordinates": [283.42, 219.95083282099603]}, {"altitude": 0.0, "coordinates": [283.42, 205.41899999999998]}, {"altitude": 0.0, "coordinates": [283.42, 205.42]}, {"altitude": 0.0, "coordinates": [275.11, 205.42]}, {"altitude": 0.0, "coordinates": [275.11, 205.44]}, {"altitude": 0.0, "coordinates": [275.10900000000004, 205.44]}]
+99	{"type": "Polygon", "coordinates": [[[275.07, 201.79], [275.08, 199.68], [277.41, 199.69], [277.41, 202.88], [277.65, 202.88], [277.65, 199.72], [283.42, 199.72], [283.41, 204.08], [277.65, 204.08], [277.65, 203.72], [277.41, 203.72], [277.41, 204.68], [277.63, 204.68], [277.63, 204.33], [283.48, 204.37], [283.48, 209.09], [277.63, 209.09], [277.63, 205.57], [277.41, 205.57], [277.41, 206.11], [276.23, 206.1], [276.23, 206.31], [277.44, 206.32], [277.44, 209.11], [275.1, 209.11], [275.1, 206.31], [275.34, 206.31], [275.34, 206.09], [275.12, 206.09], [275.11, 203.2], [274.5, 203.23], [274.5, 204.02], [272.72, 204.02], [272.72, 201.56], [274.49, 201.56], [274.49, 201.83], [275.07, 201.79]]]}	-4.10	10	\N	\N
+11	{"type": "Polygon", "coordinates": [[[272.87, 185.46], [274.47, 185.46], [274.48, 192.1], [272.72, 192.1], [272.72, 189.23], [272.36, 189.23], [272.36, 191.91], [272.15, 191.91], [272.15, 207.92], [270.55, 207.92], [270.55, 205.04], [270.25, 205.04], [270.27, 204.06], [270.56, 204.06], [270.57, 194.28], [270.33, 194.29], [270.32, 194.87], [268.94, 194.87], [268.95, 194.23], [268.7, 194.21], [268.71, 195.91], [267.23, 195.92], [267.23, 192.76], [270.54, 192.77], [270.52, 184.39], [272.36, 184.39], [272.36, 185.46], [272.72, 185.46], [272.87, 185.46]]]}	-3.60	10	\N	\N
+240	{"type": "Polygon", "coordinates": [[[283.6, 230.01], [283.6, 233.99], [272.65, 233.99], [272.65, 230.01], [283.6, 230.01]]]}	4.60	37	\N	\N
+363	{"type": "Polygon", "coordinates": [[[235.53, 211.5], [239.59, 211.51], [239.59, 205.04], [239.58, 203.75], [235.53, 203.75], [235.53, 211.5]]]}	\N	2	\N	[{"altitude": 0.6, "coordinates": [235.53, 211.50107246668534]}, {"altitude": 0.6, "coordinates": [235.53, 211.5000724637681]}, {"altitude": 0.6, "coordinates": [239.59, 211.50987922705312]}, {"altitude": 0.6, "coordinates": [239.59, 211.51087911113746]}, {"altitude": 0.0, "coordinates": [239.59, 204.9139961340779]}, {"altitude": 0.0, "coordinates": [239.59, 205.04333333333273]}, {"altitude": 0.0, "coordinates": [239.58, 203.75]}, {"altitude": 0.0, "coordinates": [235.53, 203.75]}, {"altitude": 0.0, "coordinates": [235.53, 203.749]}]
 171	{"type": "Polygon", "coordinates": [[[274.29, 138.99], [272.11, 138.78], [272.53, 134.17], [278.53, 134.67], [278.21, 137.99], [276.85, 137.9], [276.72, 139.22], [274.29, 138.99]]]}	-2.00	10	\N	\N
-277	{"type": "Polygon", "coordinates": [[[284.05, 210.67], [284.05, 209.31], [301.53, 209.31], [301.53, 210.67], [284.05, 210.67]]]}	-4.23	11	\N	\N
+70	{"type": "MultiPolygon", "coordinates": [[[[276.75, 141.18], [277.7, 141.28], [277.72, 141.02], [276.77, 140.92], [276.75, 141.18]]], [[[270.36, 194.09], [268.93, 194.09], [268.93, 194.3], [270.36, 194.3], [270.36, 194.09]]], [[[301.53, 194.38], [284.05, 194.38], [284.05, 195.77], [301.53, 195.77], [301.53, 194.38]]], [[[272.74, 233.92], [272.73, 232.33], [272.67, 232.33], [272.67, 233.92], [272.74, 233.92]]]]}	0.00	11	\N	\N
+270	{"type": "Polygon", "coordinates": [[[284.05, 201.19], [284.05, 199.83], [301.53, 199.83], [301.53, 201.19], [284.05, 201.19]]]}	-1.54	11	\N	\N
 269	{"type": "Polygon", "coordinates": [[[284.05, 198.48], [284.05, 197.12], [301.53, 197.12], [301.53, 198.48], [284.05, 198.48]]]}	-0.77	11	\N	\N
 276	{"type": "Polygon", "coordinates": [[[284.05, 209.31], [284.05, 207.96], [301.53, 207.96], [301.53, 209.31], [284.05, 209.31]]]}	-3.85	11	\N	\N
+274	{"type": "Polygon", "coordinates": [[[284.05, 206.6], [284.05, 205.25], [301.53, 205.25], [301.53, 206.6], [284.05, 206.6]]]}	-3.08	11	\N	\N
+92	{"type": "MultiPolygon", "coordinates": [[[[268.93, 196.1], [268.93, 196.4], [270.36, 196.4], [270.36, 196.1], [268.93, 196.1]]], [[[301.53, 199.83], [301.53, 198.48], [284.05, 198.48], [284.05, 199.83], [301.53, 199.83]], [[300.36, 199.75], [299.83, 199.75], [299.83, 199.24], [300.36, 199.24], [300.36, 199.75]], [[286.35, 199.75], [286.35, 199.25], [289.48, 199.25], [289.48, 199.75], [286.35, 199.75]]]]}	-1.15	11	\N	\N
+275	{"type": "Polygon", "coordinates": [[[284.05, 207.96], [284.05, 206.6], [301.53, 206.6], [301.53, 207.96], [284.05, 207.96]], [[300.36, 207.4], [299.83, 207.4], [299.83, 207.91], [300.36, 207.91], [300.36, 207.4]], [[289.5, 207.91], [289.49, 207.41], [286.35, 207.41], [286.35, 207.91], [289.5, 207.91]]]}	-3.46	11	\N	\N
+272	{"type": "Polygon", "coordinates": [[[284.05, 203.9], [284.05, 202.54], [301.53, 202.54], [301.53, 203.9], [284.05, 203.9]], [[300.36, 203.34], [299.83, 203.34], [299.83, 203.84], [300.36, 203.84], [300.36, 203.34]], [[289.5, 203.85], [289.49, 203.34], [286.34, 203.34], [286.34, 203.85], [289.5, 203.85]]]}	-2.31	11	\N	\N
+278	{"type": "Polygon", "coordinates": [[[284.05, 212.02], [284.05, 210.67], [301.53, 210.67], [301.53, 212.02], [284.05, 212.02]], [[300.36, 211.46], [299.83, 211.46], [299.83, 211.97], [300.36, 211.97], [300.36, 211.46]], [[289.49, 211.97], [289.5, 211.47], [286.34, 211.47], [286.34, 211.97], [289.49, 211.97]]]}	-4.62	11	\N	\N
+103	{"type": "Polygon", "coordinates": [[[272.72, 223.13], [274.51, 223.13], [274.51, 213.55], [272.72, 213.55], [272.72, 223.13]]]}	\N	10	\N	[{"altitude": -4.5, "coordinates": [274.50518332496233, 213.55]}, {"altitude": -4.5, "coordinates": [272.72, 213.55]}, {"altitude": -4.5, "coordinates": [272.72, 213.549]}, {"altitude": -4.5, "coordinates": [274.5051828227022, 213.549]}, {"altitude": -5.0, "coordinates": [272.72, 223.131]}, {"altitude": -5.0, "coordinates": [272.72, 223.13]}, {"altitude": -5.0, "coordinates": [274.50999497739826, 223.13]}, {"altitude": -5.0, "coordinates": [274.509995479646, 223.13099997531825]}]
+101	{"type": "Polygon", "coordinates": [[[274.48, 192.1], [272.72, 192.1], [272.72, 201.56], [274.49, 201.56], [274.48, 192.1]]]}	\N	10	\N	[{"altitude": -3.6, "coordinates": [274.4770022261799, 192.099]}, {"altitude": -3.6, "coordinates": [274.4770035618878, 192.1]}, {"altitude": -3.6, "coordinates": [272.72, 192.1]}, {"altitude": -3.6, "coordinates": [272.72, 192.099]}, {"altitude": -4.1, "coordinates": [272.72, 201.561]}, {"altitude": -4.1, "coordinates": [272.72, 201.56]}, {"altitude": -4.1, "coordinates": [274.4896393588602, 201.56]}, {"altitude": -4.1, "coordinates": [274.4896406944804, 201.56099993432932]}]
+102	{"type": "Polygon", "coordinates": [[[272.72, 211.63], [274.5, 211.63], [274.5, 204.02], [272.72, 204.02], [272.72, 211.63]]]}	\N	10	\N	[{"altitude": -4.1, "coordinates": [274.50039628327477, 204.019]}, {"altitude": -4.1, "coordinates": [274.5003967855349, 204.02]}, {"altitude": -4.1, "coordinates": [272.72, 204.02]}, {"altitude": -4.1, "coordinates": [272.72, 204.019]}, {"altitude": -4.5, "coordinates": [272.72, 211.631]}, {"altitude": -4.5, "coordinates": [272.72, 211.63]}, {"altitude": -4.5, "coordinates": [274.5042189854345, 211.63]}, {"altitude": -4.5, "coordinates": [274.50421948768224, 211.63099997531825]}]
+355	{"type": "MultiPolygon", "coordinates": [[[[270.64, 206.76], [272.37, 206.76], [272.37, 206.46], [270.64, 206.46], [270.64, 206.76]]], [[[274.99, 211.37], [274.99, 211.43], [275.11, 211.43], [275.11, 207.93], [274.99, 207.93], [274.99, 207.97], [274.5, 207.97], [274.5, 207.93], [272.66, 207.92], [272.66, 211.43], [274.54, 211.43], [274.54, 211.37], [274.99, 211.37]]]]}	0.30	2	\N	\N
+358	{"type": "MultiPolygon", "coordinates": [[[[248.95, 137.15], [252.63, 137.5], [252.65, 137.21], [249.25, 136.9], [249.58, 133.37], [249.3, 133.35], [248.95, 137.15]]], [[[269.81, 138.8], [258.42, 137.74], [258.4, 138.01], [269.79, 139.07], [269.81, 138.8]]], [[[276.59, 140.15], [274.18, 139.93], [274.15, 140.19], [276.56, 140.42], [276.59, 140.15]]]]}	0.83	2	\N	\N
+360	{"type": "MultiPolygon", "coordinates": [[[[248.29, 132.44], [247.78, 138.13], [253.37, 138.64], [253.44, 137.99], [253.18, 137.96], [253.14, 138.35], [248.07, 137.88], [248.55, 132.74], [248.98, 132.78], [249.0, 132.51], [248.29, 132.44]]], [[[270.48, 140.23], [270.53, 139.55], [270.26, 139.53], [270.22, 139.92], [257.73, 138.78], [257.77, 138.38], [257.51, 138.35], [257.45, 139.03], [270.48, 140.23]]], [[[276.48, 141.24], [274.08, 141.01], [274.05, 141.28], [276.45, 141.51], [276.48, 141.24]]]]}	0.17	2	\N	\N
+200	{"type": "Polygon", "coordinates": [[[269.03, 233.92], [266.97, 233.92], [266.97, 230.31], [269.03, 230.31], [269.03, 231.89], [268.77, 231.89], [268.76, 232.33], [269.03, 232.33], [269.03, 233.92]]]}	-2.59	11	\N	\N
 254	{"type": "Polygon", "coordinates": [[[269.03, 233.92], [266.97, 233.92], [266.97, 230.31], [269.03, 230.31], [269.03, 231.89], [268.77, 231.89], [268.76, 232.33], [269.03, 232.33], [269.03, 233.92]]]}	6.84	82	\N	\N
+267	{"type": "MultiPolygon", "coordinates": [[[[283.95, 230.86], [283.59, 230.86], [283.57, 231.59], [283.95, 231.59], [283.95, 231.93], [285.79, 231.93], [285.79, 230.23], [283.95, 230.23], [283.95, 230.86]]], [[[285.79, 232.3], [283.95, 232.3], [283.95, 232.7], [283.56, 232.7], [283.55, 233.45], [283.95, 233.45], [283.95, 234.0], [285.79, 234.0], [285.79, 232.3]]]]}	6.75	82	\N	\N
+359	{"type": "MultiPolygon", "coordinates": [[[[248.37, 137.64], [252.89, 138.06], [252.91, 137.94], [252.6, 137.91], [252.61, 137.77], [248.66, 137.4], [249.04, 133.32], [248.93, 133.31], [248.95, 133.05], [248.79, 133.04], [248.37, 137.64]]], [[[269.97, 139.65], [269.98, 139.5], [269.75, 139.48], [269.76, 139.33], [258.38, 138.29], [258.37, 138.43], [258.05, 138.4], [258.04, 138.53], [269.97, 139.65]]], [[[276.53, 140.7], [274.13, 140.47], [274.1, 140.74], [276.5, 140.97], [276.53, 140.7]]], [[[272.66, 211.99], [274.54, 211.98], [274.54, 211.71], [272.66, 211.71], [272.66, 211.99]]]]}	0.50	2	\N	\N
+357	{"type": "MultiPolygon", "coordinates": [[[[248.55, 132.74], [248.07, 137.88], [253.14, 138.35], [253.18, 137.96], [252.91, 137.94], [252.89, 138.06], [248.37, 137.64], [248.79, 133.04], [248.95, 133.05], [248.98, 132.78], [248.55, 132.74]]], [[[270.22, 139.92], [270.26, 139.53], [269.98, 139.5], [269.97, 139.65], [258.04, 138.53], [258.05, 138.4], [257.77, 138.38], [257.73, 138.78], [270.22, 139.92]]], [[[274.08, 141.01], [276.48, 141.24], [276.5, 140.97], [274.1, 140.74], [274.08, 141.01]]]]}	0.33	2	\N	\N
+14	{"type": "Polygon", "coordinates": [[[274.46, 181.71], [272.72, 181.71], [272.72, 185.46], [274.47, 185.46], [274.46, 181.71]]]}	\N	10	\N	[{"altitude": -3.45, "coordinates": [274.463124220837, 181.709]}, {"altitude": -3.45, "coordinates": [274.4631255565449, 181.71]}, {"altitude": -3.45, "coordinates": [272.72, 181.71]}, {"altitude": -3.45, "coordinates": [272.72, 181.709]}, {"altitude": -3.6, "coordinates": [272.87, 185.46]}, {"altitude": -3.6, "coordinates": [274.46813446126447, 185.46]}, {"altitude": -3.6, "coordinates": [274.46813579688467, 185.46099993432932]}, {"altitude": -3.6, "coordinates": [272.71900000000005, 185.46]}, {"altitude": -3.6, "coordinates": [272.72, 185.46]}]
+342	{"type": "MultiPolygon", "coordinates": [[[[283.95, 230.23], [283.95, 231.93], [285.79, 231.93], [285.79, 230.23], [283.95, 230.23]]], [[[285.79, 234.0], [285.79, 232.3], [283.95, 232.3], [283.95, 234.0], [285.79, 234.0]]]]}	2.10	85	\N	\N
+315	{"type": "MultiPolygon", "coordinates": [[[[248.95, 137.15], [249.3, 133.35], [249.04, 133.32], [248.66, 137.4], [252.61, 137.77], [252.63, 137.5], [248.95, 137.15]]], [[[269.79, 139.07], [258.4, 138.01], [258.38, 138.29], [269.76, 139.33], [269.79, 139.07]]], [[[274.13, 140.47], [276.53, 140.7], [276.56, 140.42], [274.15, 140.19], [274.13, 140.47]]]]}	0.67	2	\N	\N
+145	{"type": "MultiPolygon", "coordinates": [[[[346.42, 190.69], [348.27, 190.69], [348.27, 188.99], [346.42, 188.99], [346.42, 190.69]]], [[[426.91, 203.58], [425.75, 203.58], [425.75, 203.7], [426.91, 203.7], [426.91, 203.58]]], [[[339.8, 203.55], [338.52, 203.55], [338.52, 203.83], [339.8, 203.83], [339.8, 203.55]]], [[[272.73, 231.89], [272.73, 230.31], [272.39, 230.31], [272.39, 231.89], [272.73, 231.89]]]]}	0.00	85	\N	\N
+136	{"type": "MultiPolygon", "coordinates": [[[[339.9, 206.23], [339.8, 206.23], [339.8, 206.13], [338.52, 206.13], [338.52, 207.6], [339.9, 207.6], [339.9, 206.23]]], [[[425.55, 207.68], [426.91, 207.68], [426.91, 206.19], [425.63, 206.19], [425.63, 206.44], [425.55, 206.44], [425.55, 207.68]]]]}	7.43	82	\N	\N
+27	{"type": "Polygon", "coordinates": [[[270.36, 198.2], [270.36, 199.3], [267.44, 199.29], [267.43, 197.9], [268.69, 197.9], [268.69, 198.23], [268.7, 198.23], [268.93, 198.23], [268.96, 198.23], [268.96, 198.2], [270.36, 198.2]]]}	-5.23	77	\N	\N
+154	{"type": "MultiPolygon", "coordinates": [[[[339.9, 206.23], [339.8, 206.23], [339.8, 206.13], [338.52, 206.13], [338.52, 207.6], [339.9, 207.6], [339.9, 206.23]]], [[[425.75, 206.4], [425.75, 206.55], [425.71, 206.55], [425.71, 207.68], [426.91, 207.68], [426.91, 206.4], [425.75, 206.4]]]]}	1.83	85	\N	\N
+78	{"type": "Polygon", "coordinates": [[[270.36, 198.2], [270.36, 199.3], [267.44, 199.29], [267.43, 198.2], [268.71, 198.2], [268.71, 198.23], [268.93, 198.23], [268.93, 198.2], [270.36, 198.2]]]}	-2.29	11	\N	\N
+188	{"type": "MultiPolygon", "coordinates": [[[[284.05, 212.02], [284.05, 212.09], [301.53, 212.09], [301.53, 212.02], [284.05, 212.02]]], [[[272.39, 231.89], [272.73, 231.89], [272.73, 230.31], [272.39, 230.31], [272.39, 231.89]]]]}	-5.00	11	\N	\N
+123	{"type": "MultiPolygon", "coordinates": [[[[341.8, 207.6], [342.12, 207.6], [342.12, 206.24], [341.8, 206.24], [341.8, 207.6]]], [[[423.64, 207.68], [423.64, 206.43], [423.33, 206.43], [423.33, 207.68], [423.64, 207.68]]], [[[271.55, 232.33], [271.55, 233.92], [271.83, 233.92], [271.83, 232.33], [271.55, 232.33]]]]}	8.56	82	\N	\N
 113	{"type": "MultiPolygon", "coordinates": [[[[342.43, 206.24], [342.12, 206.24], [342.12, 207.6], [342.43, 207.6], [342.43, 206.24]]], [[[423.33, 207.68], [423.33, 206.43], [423.01, 206.43], [423.01, 207.68], [423.33, 207.68]]], [[[271.83, 232.33], [271.83, 233.92], [272.11, 233.92], [272.11, 232.33], [271.83, 232.33]]]]}	8.73	82	\N	\N
 150	{"type": "MultiPolygon", "coordinates": [[[[339.8, 205.27], [339.8, 204.98], [338.52, 204.98], [338.52, 205.27], [339.8, 205.27]]], [[[426.91, 205.05], [425.75, 205.05], [425.75, 205.39], [426.91, 205.39], [426.91, 205.05]]], [[[270.71, 230.31], [270.71, 231.89], [270.99, 231.89], [270.99, 230.31], [270.71, 230.31]]]]}	1.02	85	\N	\N
 127	{"type": "MultiPolygon", "coordinates": [[[[339.8, 203.54], [339.8, 203.26], [338.52, 203.26], [338.52, 203.54], [339.8, 203.54]]], [[[426.91, 203.3], [425.63, 203.3], [425.63, 203.59], [426.91, 203.59], [426.91, 203.3]]], [[[270.43, 230.31], [270.43, 231.89], [270.71, 231.89], [270.71, 230.31], [270.43, 230.31]]]]}	5.81	82	\N	\N
 155	{"type": "MultiPolygon", "coordinates": [[[[340.22, 206.23], [339.9, 206.23], [339.9, 207.6], [340.22, 207.6], [340.22, 206.23]]], [[[425.71, 207.68], [425.71, 206.55], [425.5, 206.55], [425.5, 207.68], [425.71, 207.68]]], [[[269.03, 230.31], [269.03, 231.89], [269.31, 231.89], [269.31, 230.31], [269.03, 230.31]]]]}	2.04	85	\N	\N
 137	{"type": "MultiPolygon", "coordinates": [[[[340.22, 206.23], [339.9, 206.23], [339.9, 207.6], [340.22, 207.6], [340.22, 206.23]]], [[[425.23, 207.68], [425.55, 207.68], [425.55, 206.44], [425.23, 206.44], [425.23, 207.68]]]]}	7.59	82	\N	\N
 140	{"type": "MultiPolygon", "coordinates": [[[[341.17, 206.23], [340.85, 206.23], [340.85, 207.6], [341.17, 207.6], [341.17, 206.23]]], [[[424.28, 207.68], [424.6, 207.68], [424.6, 206.44], [424.28, 206.44], [424.28, 207.68]]]]}	8.08	82	\N	\N
-200	{"type": "Polygon", "coordinates": [[[269.03, 233.92], [266.97, 233.92], [266.97, 230.31], [269.03, 230.31], [269.03, 231.89], [268.77, 231.89], [268.76, 232.33], [269.03, 232.33], [269.03, 233.92]]]}	-2.59	11	\N	\N
 142	{"type": "MultiPolygon", "coordinates": [[[[341.8, 206.24], [341.48, 206.24], [341.48, 207.6], [341.8, 207.6], [341.8, 206.24]]], [[[423.64, 207.68], [423.96, 207.68], [423.96, 206.43], [423.64, 206.43], [423.64, 207.68]]]]}	8.40	82	\N	\N
 114	{"type": "MultiPolygon", "coordinates": [[[[342.75, 206.24], [342.43, 206.24], [342.43, 207.6], [342.75, 207.6], [342.75, 206.24]]], [[[422.69, 207.68], [423.01, 207.68], [423.01, 206.43], [422.69, 206.43], [422.69, 207.68]]]]}	8.89	82	\N	\N
 81	{"type": "MultiPolygon", "coordinates": [[[[267.43, 197.3], [267.43, 197.6], [268.71, 197.6], [268.71, 197.3], [267.43, 197.3]]], [[[269.31, 230.31], [269.03, 230.31], [269.03, 231.89], [269.31, 231.89], [269.31, 230.31]]]]}	-2.78	11	\N	\N
@@ -3396,7 +3442,6 @@ COPY public.mapdata_altitudearea (id, geometry, altitude, level_id, import_tag, 
 153	{"type": "MultiPolygon", "coordinates": [[[[339.8, 206.13], [339.8, 205.84], [338.52, 205.84], [338.52, 206.13], [339.8, 206.13]]], [[[426.91, 206.4], [426.91, 206.06], [425.75, 206.06], [425.75, 206.4], [426.91, 206.4]]]]}	1.63	85	\N	\N
 117	{"type": "MultiPolygon", "coordinates": [[[[341.77, 202.48], [342.06, 202.48], [342.06, 201.23], [341.77, 201.23], [341.77, 202.48]]], [[[423.62, 201.31], [423.34, 201.31], [423.34, 202.67], [423.62, 202.67], [423.62, 201.31]]]]}	4.36	82	\N	\N
 115	{"type": "MultiPolygon", "coordinates": [[[[342.35, 202.48], [342.64, 202.48], [342.64, 201.23], [342.35, 201.23], [342.35, 202.48]]], [[[423.06, 201.31], [422.78, 201.31], [422.78, 202.67], [423.06, 202.67], [423.06, 201.31]]]]}	4.03	82	\N	\N
-100	{"type": "Polygon", "coordinates": [[[274.51, 213.55], [272.72, 213.55], [272.72, 211.63], [274.5, 211.63], [274.51, 213.55]]]}	-4.50	10	\N	\N
 116	{"type": "MultiPolygon", "coordinates": [[[[342.06, 202.48], [342.35, 202.48], [342.35, 201.23], [342.06, 201.23], [342.06, 202.48]]], [[[423.34, 201.31], [423.06, 201.31], [423.06, 202.67], [423.34, 202.67], [423.34, 201.31]]]]}	4.19	82	\N	\N
 118	{"type": "MultiPolygon", "coordinates": [[[[341.48, 202.48], [341.77, 202.48], [341.77, 201.23], [341.48, 201.23], [341.48, 202.48]]], [[[423.9, 201.31], [423.62, 201.31], [423.62, 202.67], [423.9, 202.67], [423.9, 201.31]]]]}	4.52	82	\N	\N
 121	{"type": "MultiPolygon", "coordinates": [[[[340.6, 202.47], [340.89, 202.47], [340.89, 201.23], [340.6, 201.23], [340.6, 202.47]]], [[[424.73, 201.31], [424.45, 201.31], [424.45, 202.68], [424.73, 202.68], [424.73, 201.31]]]]}	5.00	82	\N	\N
@@ -3411,7 +3456,6 @@ COPY public.mapdata_altitudearea (id, geometry, altitude, level_id, import_tag, 
 129	{"type": "MultiPolygon", "coordinates": [[[[339.8, 204.12], [339.8, 203.83], [338.52, 203.83], [338.52, 204.12], [339.8, 204.12]]], [[[426.91, 204.17], [426.91, 203.88], [425.63, 203.88], [425.63, 204.17], [426.91, 204.17]]]]}	6.14	82	\N	\N
 131	{"type": "MultiPolygon", "coordinates": [[[[339.8, 204.98], [339.8, 204.69], [338.52, 204.69], [338.52, 204.98], [339.8, 204.98]]], [[[426.91, 205.03], [426.91, 204.74], [425.63, 204.74], [425.63, 205.03], [426.91, 205.03]]]]}	6.62	82	\N	\N
 135	{"type": "MultiPolygon", "coordinates": [[[[339.8, 206.13], [339.8, 205.84], [338.52, 205.84], [338.52, 206.13], [339.8, 206.13]]], [[[426.91, 206.19], [426.91, 205.9], [425.63, 205.9], [425.63, 206.19], [426.91, 206.19]]]]}	7.27	82	\N	\N
-226	{"type": "Polygon", "coordinates": [[[269.03, 233.92], [266.97, 233.92], [266.97, 230.31], [269.03, 230.31], [269.03, 231.89], [268.77, 231.89], [268.76, 232.33], [269.03, 232.33], [269.03, 233.92]]]}	2.21	85	\N	\N
 119	{"type": "MultiPolygon", "coordinates": [[[[341.18, 202.47], [341.48, 202.48], [341.48, 201.23], [341.18, 201.23], [341.18, 202.47]]], [[[424.17, 201.31], [423.9, 201.31], [423.9, 202.67], [424.17, 202.68], [424.17, 201.31]]]]}	4.68	82	\N	\N
 148	{"type": "MultiPolygon", "coordinates": [[[[426.91, 204.71], [426.91, 204.38], [425.75, 204.38], [425.75, 204.71], [426.91, 204.71]]], [[[339.8, 204.69], [339.8, 204.41], [338.52, 204.41], [338.52, 204.69], [339.8, 204.69]]]]}	0.61	85	\N	\N
 152	{"type": "MultiPolygon", "coordinates": [[[[339.8, 205.84], [339.8, 205.56], [338.52, 205.56], [338.52, 205.84], [339.8, 205.84]]], [[[426.91, 206.06], [426.91, 205.73], [425.75, 205.73], [425.75, 206.06], [426.91, 206.06]]]]}	1.43	85	\N	\N
@@ -3423,21 +3467,22 @@ COPY public.mapdata_altitudearea (id, geometry, altitude, level_id, import_tag, 
 167	{"type": "Polygon", "coordinates": [[[276.52, 141.19], [276.49, 141.47], [274.04, 141.24], [274.07, 140.96], [276.52, 141.19]]]}	-3.29	10	\N	\N
 168	{"type": "Polygon", "coordinates": [[[276.58, 140.63], [276.55, 140.91], [274.1, 140.68], [274.13, 140.4], [276.58, 140.63]]]}	-2.97	10	\N	\N
 174	{"type": "Polygon", "coordinates": [[[274.2, 139.83], [274.23, 139.55], [276.66, 139.78], [276.63, 140.06], [274.2, 139.83]]]}	-2.48	10	\N	\N
-175	{"type": "Polygon", "coordinates": [[[274.26, 139.27], [274.29, 138.99], [276.72, 139.22], [276.69, 139.5], [274.26, 139.27]]]}	-2.16	10	\N	\N
 170	{"type": "Polygon", "coordinates": [[[276.69, 139.5], [276.66, 139.78], [274.23, 139.55], [274.26, 139.27], [276.69, 139.5]]]}	-2.32	10	\N	\N
 157	{"type": "MultiPolygon", "coordinates": [[[[340.85, 206.23], [340.53, 206.23], [340.53, 207.6], [340.85, 207.6], [340.85, 206.23]]], [[[425.28, 206.55], [425.07, 206.55], [425.07, 207.68], [425.28, 207.68], [425.28, 206.55]]]]}	2.44	85	\N	\N
+158	{"type": "MultiPolygon", "coordinates": [[[[341.17, 206.23], [340.85, 206.23], [340.85, 207.6], [341.17, 207.6], [341.17, 206.23]]], [[[425.07, 206.55], [424.86, 206.55], [424.86, 207.68], [425.07, 207.68], [425.07, 206.55]]]]}	2.65	85	\N	\N
 160	{"type": "MultiPolygon", "coordinates": [[[[341.8, 206.24], [341.48, 206.24], [341.48, 207.6], [341.8, 207.6], [341.8, 206.24]]], [[[424.64, 206.54], [424.43, 206.54], [424.43, 207.68], [424.64, 207.68], [424.64, 206.54]]]]}	3.06	85	\N	\N
 161	{"type": "MultiPolygon", "coordinates": [[[[342.12, 206.24], [341.8, 206.24], [341.8, 207.6], [342.12, 207.6], [342.12, 206.24]]], [[[424.43, 206.54], [424.22, 206.54], [424.22, 207.68], [424.43, 207.68], [424.43, 206.54]]]]}	3.26	85	\N	\N
-124	{"type": "MultiPolygon", "coordinates": [[[[339.8, 202.68], [339.8, 202.47], [340.31, 202.47], [340.31, 201.23], [338.52, 201.23], [338.52, 202.68], [339.8, 202.68]]], [[[426.91, 202.72], [426.91, 201.31], [425.01, 201.31], [425.01, 202.68], [425.63, 202.68], [425.63, 202.72], [426.91, 202.72]]]]}	5.33	82	\N	\N
+163	{"type": "MultiPolygon", "coordinates": [[[[342.75, 206.24], [342.43, 206.24], [342.43, 207.6], [342.75, 207.6], [342.75, 206.24]]], [[[424.0, 206.54], [423.79, 206.54], [423.79, 207.68], [424.0, 207.68], [424.0, 206.54]]]]}	3.67	85	\N	\N
 156	{"type": "MultiPolygon", "coordinates": [[[[340.53, 206.23], [340.22, 206.23], [340.22, 207.6], [340.53, 207.6], [340.53, 206.23]]], [[[425.5, 206.55], [425.28, 206.55], [425.28, 207.68], [425.5, 207.68], [425.5, 206.55]]]]}	2.24	85	\N	\N
 159	{"type": "MultiPolygon", "coordinates": [[[[341.48, 206.24], [341.17, 206.23], [341.17, 207.6], [341.48, 207.6], [341.48, 206.24]]], [[[424.86, 206.55], [424.64, 206.54], [424.64, 207.68], [424.86, 207.68], [424.86, 206.55]]]]}	2.85	85	\N	\N
 162	{"type": "MultiPolygon", "coordinates": [[[[342.43, 206.24], [342.12, 206.24], [342.12, 207.6], [342.43, 207.6], [342.43, 206.24]]], [[[424.22, 206.54], [424.0, 206.54], [424.0, 207.68], [424.22, 207.68], [424.22, 206.54]]]]}	3.46	85	\N	\N
-241	{"type": "Polygon", "coordinates": [[[272.39, 230.31], [272.73, 230.31], [272.73, 231.89], [272.39, 231.89], [272.39, 230.31]]]}	4.60	82	\N	\N
+362	{"type": "Polygon", "coordinates": [[[272.37, 206.15], [272.37, 206.46], [270.64, 206.46], [270.64, 206.15], [272.37, 206.15]]]}	0.15	2	\N	\N
 361	{"type": "Polygon", "coordinates": [[[272.37, 206.76], [272.37, 207.07], [270.64, 207.07], [270.64, 206.76], [272.37, 206.76]]]}	0.45	2	\N	\N
 356	{"type": "Polygon", "coordinates": [[[274.5, 207.36], [274.5, 207.65], [272.66, 207.65], [272.66, 207.36], [274.5, 207.36]]]}	0.10	2	\N	\N
 354	{"type": "Polygon", "coordinates": [[[274.54, 211.43], [274.54, 211.71], [272.66, 211.71], [272.66, 211.43], [274.54, 211.43]]]}	0.40	2	\N	\N
 112	{"type": "MultiPolygon", "coordinates": [[[[342.64, 202.48], [342.83, 202.48], [342.83, 201.23], [342.64, 201.23], [342.64, 202.48]]], [[[422.78, 201.31], [422.57, 201.31], [422.57, 202.67], [422.78, 202.67], [422.78, 201.31]]]]}	3.87	82	\N	\N
 353	{"type": "Polygon", "coordinates": [[[274.5, 207.65], [274.5, 207.93], [272.66, 207.92], [272.66, 207.65], [274.5, 207.65]]]}	0.20	2	\N	\N
+181	{"type": "Polygon", "coordinates": [[[277.0, 138.49], [277.05, 137.98], [278.0, 138.08], [277.95, 138.59], [277.0, 138.49]]]}	-2.00	11	\N	\N
 201	{"type": "Polygon", "coordinates": [[[269.31, 233.92], [269.03, 233.92], [269.03, 232.33], [269.31, 232.33], [269.31, 233.92]]]}	-2.41	11	\N	\N
 203	{"type": "Polygon", "coordinates": [[[269.87, 233.92], [269.59, 233.92], [269.59, 232.33], [269.87, 232.33], [269.87, 233.92]]]}	-2.04	11	\N	\N
 205	{"type": "Polygon", "coordinates": [[[270.43, 233.92], [270.15, 233.92], [270.15, 232.33], [270.43, 232.33], [270.43, 233.92]]]}	-1.67	11	\N	\N
@@ -3489,7 +3534,18 @@ COPY public.mapdata_altitudearea (id, geometry, altitude, level_id, import_tag, 
 248	{"type": "Polygon", "coordinates": [[[270.99, 231.89], [270.71, 231.89], [270.71, 230.31], [270.99, 230.31], [270.99, 231.89]]]}	5.63	82	\N	\N
 247	{"type": "Polygon", "coordinates": [[[270.43, 231.89], [270.15, 231.89], [270.15, 230.31], [270.43, 230.31], [270.43, 231.89]]]}	5.98	82	\N	\N
 245	{"type": "Polygon", "coordinates": [[[269.87, 231.89], [269.59, 231.89], [269.59, 230.31], [269.87, 230.31], [269.87, 231.89]]]}	6.32	82	\N	\N
+243	{"type": "Polygon", "coordinates": [[[269.31, 231.89], [269.03, 231.89], [269.03, 230.31], [269.31, 230.31], [269.31, 231.89]]]}	6.67	82	\N	\N
+199	{"type": "Polygon", "coordinates": [[[272.39, 231.89], [272.11, 231.89], [272.11, 230.31], [272.39, 230.31], [272.39, 231.89]]]}	-4.81	11	\N	\N
+197	{"type": "Polygon", "coordinates": [[[271.83, 231.89], [271.55, 231.89], [271.55, 230.31], [271.83, 230.31], [271.83, 231.89]]]}	-4.44	11	\N	\N
 195	{"type": "Polygon", "coordinates": [[[271.27, 231.89], [270.99, 231.89], [270.99, 230.31], [271.27, 230.31], [271.27, 231.89]]]}	-4.07	11	\N	\N
+193	{"type": "Polygon", "coordinates": [[[270.71, 231.89], [270.43, 231.89], [270.43, 230.31], [270.71, 230.31], [270.71, 231.89]]]}	-3.70	11	\N	\N
+191	{"type": "Polygon", "coordinates": [[[270.15, 231.89], [269.87, 231.89], [269.87, 230.31], [270.15, 230.31], [270.15, 231.89]]]}	-3.33	11	\N	\N
+189	{"type": "Polygon", "coordinates": [[[269.59, 231.89], [269.31, 231.89], [269.31, 230.31], [269.59, 230.31], [269.59, 231.89]]]}	-2.96	11	\N	\N
+225	{"type": "Polygon", "coordinates": [[[272.39, 231.89], [272.11, 231.89], [272.11, 230.31], [272.39, 230.31], [272.39, 231.89]]]}	0.17	85	\N	\N
+223	{"type": "Polygon", "coordinates": [[[271.83, 231.89], [271.55, 231.89], [271.55, 230.31], [271.83, 230.31], [271.83, 231.89]]]}	0.51	85	\N	\N
+221	{"type": "Polygon", "coordinates": [[[271.27, 231.89], [270.99, 231.89], [270.99, 230.31], [271.27, 230.31], [271.27, 231.89]]]}	0.85	85	\N	\N
+220	{"type": "Polygon", "coordinates": [[[270.71, 231.89], [270.43, 231.89], [270.43, 230.31], [270.71, 230.31], [270.71, 231.89]]]}	1.19	85	\N	\N
+218	{"type": "Polygon", "coordinates": [[[270.15, 231.89], [269.87, 231.89], [269.87, 230.31], [270.15, 230.31], [270.15, 231.89]]]}	1.53	85	\N	\N
 216	{"type": "Polygon", "coordinates": [[[269.59, 231.89], [269.31, 231.89], [269.31, 230.31], [269.59, 230.31], [269.59, 231.89]]]}	1.87	85	\N	\N
 253	{"type": "Polygon", "coordinates": [[[272.39, 231.89], [272.11, 231.89], [272.11, 230.31], [272.39, 230.31], [272.39, 231.89]]]}	4.77	82	\N	\N
 251	{"type": "Polygon", "coordinates": [[[271.83, 231.89], [271.55, 231.89], [271.55, 230.31], [271.83, 230.31], [271.83, 231.89]]]}	5.12	82	\N	\N
@@ -3512,40 +3568,24 @@ COPY public.mapdata_altitudearea (id, geometry, altitude, level_id, import_tag, 
 36	{"type": "Polygon", "coordinates": [[[270.36, 196.7], [270.36, 197.0], [268.96, 197.0], [268.96, 196.7], [270.36, 196.7]]]}	-4.42	77	\N	\N
 38	{"type": "Polygon", "coordinates": [[[270.36, 196.1], [270.36, 196.4], [268.96, 196.4], [268.96, 196.1], [270.36, 196.1]]]}	-4.09	77	\N	\N
 40	{"type": "Polygon", "coordinates": [[[270.36, 195.5], [270.36, 195.8], [268.96, 195.8], [268.96, 195.5], [270.36, 195.5]]]}	-3.76	77	\N	\N
-33	{"type": "Polygon", "coordinates": [[[270.36, 197.9], [270.36, 198.2], [268.96, 198.2], [268.96, 197.9], [270.36, 197.9]]]}	-5.07	77	\N	\N
-83	{"type": "Polygon", "coordinates": [[[268.7, 196.7], [268.7, 197.0], [267.43, 197.0], [267.42, 196.7], [268.7, 196.7]]]}	-3.11	11	\N	\N
-28	{"type": "Polygon", "coordinates": [[[267.42, 196.7], [267.42, 196.4], [268.69, 196.4], [268.69, 196.7], [267.42, 196.7]]]}	-6.05	77	\N	\N
-29	{"type": "Polygon", "coordinates": [[[268.69, 196.7], [268.69, 197.0], [267.43, 197.0], [267.42, 196.7], [268.69, 196.7]]]}	-5.88	77	\N	\N
-31	{"type": "Polygon", "coordinates": [[[267.43, 197.6], [267.43, 197.3], [268.69, 197.3], [268.69, 197.6], [267.43, 197.6]]]}	-5.56	77	\N	\N
-144	{"type": "MultiPolygon", "coordinates": [[[[342.75, 207.6], [342.86, 207.6], [342.86, 206.24], [342.75, 206.24], [342.75, 207.6]]], [[[423.79, 206.54], [423.63, 206.54], [423.63, 207.68], [423.79, 207.68], [423.79, 206.54]]]]}	3.87	85	\N	\N
-77	{"type": "Polygon", "coordinates": [[[267.42, 196.1], [267.42, 195.86], [268.7, 195.86], [268.7, 196.1], [267.42, 196.1]]]}	-3.60	11	\N	\N
-105	{"type": "MultiPolygon", "coordinates": [[[[342.75, 207.6], [342.88, 207.6], [342.88, 206.24], [342.75, 206.24], [342.75, 207.6]]], [[[422.69, 206.43], [422.6, 206.43], [422.6, 207.68], [422.69, 207.68], [422.69, 206.43]]]]}	9.05	82	\N	\N
-176	{"type": "Polygon", "coordinates": [[[277.62, 142.09], [277.59, 142.39], [276.64, 142.29], [276.67, 142.0], [277.62, 142.09]]]}	1.00	11	\N	\N
-199	{"type": "Polygon", "coordinates": [[[272.39, 231.89], [272.11, 231.89], [272.11, 230.31], [272.39, 230.31], [272.39, 231.89]]]}	-4.81	11	\N	\N
-197	{"type": "Polygon", "coordinates": [[[271.83, 231.89], [271.55, 231.89], [271.55, 230.31], [271.83, 230.31], [271.83, 231.89]]]}	-4.44	11	\N	\N
-215	{"type": "Polygon", "coordinates": [[[272.67, 232.33], [272.73, 232.33], [272.74, 233.92], [272.67, 233.92], [272.67, 232.33]]]}	4.60	85	\N	\N
-242	{"type": "Polygon", "coordinates": [[[272.67, 232.33], [272.73, 232.33], [272.74, 233.92], [272.67, 233.92], [272.67, 232.33]]]}	9.25	82	\N	\N
-363	{"type": "Polygon", "coordinates": [[[239.59, 205.04], [239.58, 203.75], [235.53, 203.75], [235.53, 211.5], [239.59, 211.51], [239.59, 205.04]]]}	\N	2	\N	[{"altitude": 0.6, "coordinates": [235.53, 211.50107246668534]}, {"altitude": 0.6, "coordinates": [235.53, 211.5000724637681]}, {"altitude": 0.6, "coordinates": [239.59, 211.50987922705312]}, {"altitude": 0.6, "coordinates": [239.59, 211.51087911113746]}, {"altitude": 0.0, "coordinates": [239.59, 204.9139961340779]}, {"altitude": 0.0, "coordinates": [239.59, 205.04333333333273]}, {"altitude": 0.0, "coordinates": [239.58, 203.75]}, {"altitude": 0.0, "coordinates": [235.53, 203.75]}, {"altitude": 0.0, "coordinates": [235.53, 203.749]}]
-272	{"type": "Polygon", "coordinates": [[[284.05, 203.9], [284.05, 202.54], [301.53, 202.54], [301.53, 203.9], [284.05, 203.9]], [[300.36, 203.84], [300.36, 203.34], [299.83, 203.34], [299.83, 203.84], [300.36, 203.84]], [[286.34, 203.85], [289.5, 203.85], [289.49, 203.34], [286.34, 203.34], [286.34, 203.85]]]}	-2.31	11	\N	\N
-103	{"type": "Polygon", "coordinates": [[[272.72, 223.13], [274.51, 223.13], [274.51, 213.55], [272.72, 213.55], [272.72, 223.13]]]}	\N	10	\N	[{"altitude": -4.5, "coordinates": [274.50518332496233, 213.55]}, {"altitude": -4.5, "coordinates": [272.72, 213.55]}, {"altitude": -4.5, "coordinates": [272.72, 213.549]}, {"altitude": -4.5, "coordinates": [274.5051828227022, 213.549]}, {"altitude": -5.0, "coordinates": [272.72, 223.131]}, {"altitude": -5.0, "coordinates": [272.72, 223.13]}, {"altitude": -5.0, "coordinates": [274.50999497739826, 223.13]}, {"altitude": -5.0, "coordinates": [274.509995479646, 223.13099997531825]}]
-101	{"type": "Polygon", "coordinates": [[[274.48, 192.1], [272.72, 192.1], [272.72, 201.56], [274.49, 201.56], [274.48, 192.1]]]}	\N	10	\N	[{"altitude": -3.6, "coordinates": [274.4770022261799, 192.099]}, {"altitude": -3.6, "coordinates": [274.4770035618878, 192.1]}, {"altitude": -3.6, "coordinates": [272.72, 192.1]}, {"altitude": -3.6, "coordinates": [272.72, 192.099]}, {"altitude": -4.1, "coordinates": [272.72, 201.561]}, {"altitude": -4.1, "coordinates": [272.72, 201.56]}, {"altitude": -4.1, "coordinates": [274.4896393588602, 201.56]}, {"altitude": -4.1, "coordinates": [274.4896406944804, 201.56099993432932]}]
-34	{"type": "Polygon", "coordinates": [[[270.36, 197.3], [270.36, 197.6], [268.96, 197.6], [268.96, 197.3], [270.36, 197.3]]]}	-4.74	77	\N	\N
-37	{"type": "Polygon", "coordinates": [[[270.36, 196.4], [270.36, 196.7], [268.96, 196.7], [268.96, 196.4], [270.36, 196.4]]]}	-4.25	77	\N	\N
 39	{"type": "Polygon", "coordinates": [[[270.36, 195.8], [270.36, 196.1], [268.96, 196.1], [268.96, 195.8], [270.36, 195.8]]]}	-3.93	77	\N	\N
 26	{"type": "Polygon", "coordinates": [[[268.96, 195.5], [268.96, 195.22], [270.36, 195.22], [270.36, 195.5], [268.96, 195.5]]]}	-3.60	77	\N	\N
 85	{"type": "Polygon", "coordinates": [[[268.7, 196.1], [268.7, 196.4], [267.42, 196.4], [267.42, 196.1], [268.7, 196.1]]]}	-3.44	11	\N	\N
 80	{"type": "Polygon", "coordinates": [[[268.71, 197.6], [268.71, 197.9], [267.43, 197.9], [267.43, 197.6], [268.71, 197.6]]]}	-2.62	11	\N	\N
 84	{"type": "Polygon", "coordinates": [[[268.7, 196.4], [268.7, 196.7], [267.42, 196.7], [267.42, 196.4], [268.7, 196.4]]]}	-3.27	11	\N	\N
 79	{"type": "Polygon", "coordinates": [[[268.71, 197.9], [268.71, 198.2], [267.43, 198.2], [267.43, 197.9], [268.71, 197.9]]]}	-2.45	11	\N	\N
-364	{"type": "Polygon", "coordinates": [[[274.99, 207.93], [275.11, 207.93], [275.11, 211.43], [274.99, 211.43], [274.99, 211.71], [274.99, 211.98], [274.99, 219.93], [275.11, 219.93], [283.42, 219.95], [283.42, 222.0], [283.68, 222.0], [283.68, 219.95], [283.68, 205.42], [283.68, 194.36], [283.42, 194.36], [283.42, 205.42], [275.11, 205.42], [275.11, 205.44], [274.99, 205.44], [274.99, 207.36], [274.99, 207.65], [274.99, 207.93]], [[275.13, 211.71], [275.13, 211.43], [275.13, 211.37], [275.16, 211.37], [275.16, 212.03], [275.13, 212.03], [275.13, 211.98], [275.13, 211.71]]]}	\N	2	\N	[{"altitude": 0.6, "coordinates": [275.10900005786385, 219.93]}, {"altitude": 0.6, "coordinates": [275.11, 219.93]}, {"altitude": 0.6, "coordinates": [283.42, 219.94983293556083]}, {"altitude": 0.6, "coordinates": [283.42, 219.95083282099603]}, {"altitude": 0.0, "coordinates": [283.42, 205.41899999999998]}, {"altitude": 0.0, "coordinates": [283.42, 205.42]}, {"altitude": 0.0, "coordinates": [275.11, 205.42]}, {"altitude": 0.0, "coordinates": [275.11, 205.44]}, {"altitude": 0.0, "coordinates": [275.10900000000004, 205.44]}]
-102	{"type": "Polygon", "coordinates": [[[272.72, 211.63], [274.5, 211.63], [274.5, 204.02], [272.72, 204.02], [272.72, 211.63]]]}	\N	10	\N	[{"altitude": -4.1, "coordinates": [274.50039628327477, 204.019]}, {"altitude": -4.1, "coordinates": [274.5003967855349, 204.02]}, {"altitude": -4.1, "coordinates": [272.72, 204.02]}, {"altitude": -4.1, "coordinates": [272.72, 204.019]}, {"altitude": -4.5, "coordinates": [272.72, 211.631]}, {"altitude": -4.5, "coordinates": [272.72, 211.63]}, {"altitude": -4.5, "coordinates": [274.5042189854345, 211.63]}, {"altitude": -4.5, "coordinates": [274.50421948768224, 211.63099997531825]}]
-355	{"type": "MultiPolygon", "coordinates": [[[[270.64, 206.76], [272.37, 206.76], [272.37, 206.46], [270.64, 206.46], [270.64, 206.76]]], [[[274.99, 211.37], [274.99, 211.43], [275.11, 211.43], [275.11, 207.93], [274.99, 207.93], [274.99, 207.97], [274.5, 207.97], [274.5, 207.93], [272.66, 207.92], [272.66, 211.43], [274.54, 211.43], [274.54, 211.37], [274.99, 211.37]]]]}	0.30	2	\N	\N
-182	{"type": "Polygon", "coordinates": [[[276.67, 142.0], [276.69, 141.73], [277.64, 141.82], [277.62, 142.09], [276.67, 142.0]]]}	0.75	11	\N	\N
-180	{"type": "Polygon", "coordinates": [[[277.93, 138.86], [277.9, 139.12], [276.95, 139.03], [276.97, 138.77], [277.93, 138.86]]]}	-1.50	11	\N	\N
-280	{"type": "MultiPolygon", "coordinates": [[[[270.64, 207.07], [270.66, 211.77], [270.68, 211.77], [270.68, 211.96], [239.59, 211.96], [239.59, 211.59], [239.59, 211.53], [239.59, 211.51], [235.53, 211.5], [235.53, 211.57], [235.54, 211.57], [235.54, 211.96], [205.64, 211.96], [205.64, 223.14], [268.38, 223.22], [268.38, 223.58], [259.65, 223.58], [259.65, 224.91], [260.82, 224.91], [260.82, 225.12], [259.82, 225.12], [259.85, 226.99], [262.01, 226.99], [262.01, 225.12], [261.93, 225.12], [261.93, 224.91], [263.6, 224.91], [263.6, 225.16], [263.44, 225.16], [263.44, 229.52], [265.89, 229.52], [265.89, 225.16], [264.48, 225.16], [264.48, 224.91], [267.63, 224.91], [267.63, 225.16], [266.27, 225.17], [266.26, 229.52], [268.74, 229.52], [268.72, 225.16], [268.57, 225.16], [268.57, 224.91], [271.86, 224.91], [271.86, 223.58], [270.2, 223.58], [270.2, 223.22], [272.22, 223.22], [272.22, 211.96], [272.15, 211.96], [272.15, 211.77], [272.37, 211.77], [272.37, 207.07], [270.64, 207.07]]], [[[272.66, 211.99], [272.66, 222.0], [277.48, 222.0], [277.48, 222.45], [272.73, 222.44], [272.75, 223.59], [271.96, 223.61], [271.92, 224.88], [272.73, 224.88], [272.73, 234.31], [283.53, 234.31], [283.53, 233.45], [284.05, 233.45], [284.05, 232.57], [283.53, 232.57], [283.53, 231.57], [284.03, 231.57], [284.03, 230.76], [283.53, 230.76], [283.53, 229.81], [300.46, 229.81], [300.46, 227.62], [302.65, 227.57], [302.59, 224.95], [300.46, 224.9], [300.46, 222.51], [281.13, 222.46], [281.13, 222.0], [283.42, 222.0], [283.42, 219.95], [275.11, 219.93], [274.99, 219.93], [274.99, 212.03], [274.54, 212.03], [274.54, 211.98], [272.66, 211.99]], [[279.35, 222.46], [279.17, 222.46], [279.17, 222.0], [279.35, 222.0], [279.35, 222.46]]]]}	0.60	2	\N	\N
-341	{"type": "Polygon", "coordinates": [[[412.37, 189.46], [412.37, 189.21], [411.86, 189.21], [411.86, 186.02], [414.01, 186.02], [414.01, 189.21], [413.9, 189.21], [413.9, 189.46], [414.01, 189.46], [414.01, 190.8], [427.24, 190.83], [427.24, 195.42], [426.53, 195.42], [426.54, 197.11], [426.39, 197.11], [426.39, 197.3], [427.08, 197.3], [427.08, 202.42], [422.86, 202.42], [422.8, 203.16], [422.1, 203.22], [422.08, 205.35], [422.82, 205.38], [422.85, 207.52], [422.38, 207.52], [422.38, 207.2], [403.68, 207.16], [403.54, 197.3], [422.17, 197.3], [422.17, 197.1], [422.14, 195.49], [343.48, 195.47], [343.46, 197.08], [343.47, 197.08], [343.47, 197.25], [360.03, 197.25], [360.03, 207.2], [343.83, 207.2], [343.83, 207.55], [342.82, 207.55], [342.83, 205.37], [343.57, 205.37], [343.57, 203.22], [342.78, 203.22], [342.78, 202.5], [338.62, 202.5], [338.62, 197.45], [338.99, 197.45], [338.99, 197.25], [339.29, 197.25], [339.29, 197.11], [339.26, 190.78], [349.83, 190.78], [349.83, 190.64], [348.54, 190.64], [348.54, 190.59], [348.27, 190.59], [348.27, 190.69], [346.42, 190.69], [346.42, 188.99], [348.27, 188.99], [348.27, 189.54], [348.54, 189.54], [348.54, 189.04], [350.58, 189.04], [350.56, 190.78], [411.87, 190.78], [411.87, 189.46], [412.37, 189.46]], [[341.71, 197.11], [341.06, 197.11], [341.06, 197.25], [341.71, 197.25], [341.71, 197.11]], [[424.73, 197.3], [424.73, 197.11], [423.95, 197.1], [423.95, 197.3], [424.73, 197.3]]]}	9.05	38	\N	\N
-360	{"type": "MultiPolygon", "coordinates": [[[[248.29, 132.44], [247.78, 138.13], [253.37, 138.64], [253.44, 137.99], [253.18, 137.96], [253.14, 138.35], [248.07, 137.88], [248.55, 132.74], [248.98, 132.78], [249.0, 132.51], [248.29, 132.44]]], [[[270.48, 140.23], [270.53, 139.55], [270.26, 139.53], [270.22, 139.92], [257.73, 138.78], [257.77, 138.38], [257.51, 138.35], [257.45, 139.03], [270.48, 140.23]]], [[[276.48, 141.24], [274.08, 141.01], [274.05, 141.28], [276.45, 141.51], [276.48, 141.24]]]]}	0.17	2	\N	\N
-11	{"type": "Polygon", "coordinates": [[[272.87, 185.46], [274.47, 185.46], [274.48, 192.1], [272.72, 192.1], [272.72, 189.23], [272.36, 189.23], [272.36, 191.91], [272.15, 191.91], [272.15, 207.92], [270.55, 207.92], [270.55, 205.04], [270.25, 205.04], [270.27, 204.06], [270.56, 204.06], [270.57, 194.28], [270.33, 194.29], [270.32, 194.87], [268.94, 194.87], [268.95, 194.23], [268.7, 194.21], [268.71, 195.91], [267.23, 195.92], [267.23, 192.76], [270.54, 192.77], [270.52, 184.39], [272.36, 184.39], [272.36, 185.46], [272.72, 185.46], [272.87, 185.46]]]}	-3.60	10	\N	\N
+83	{"type": "Polygon", "coordinates": [[[268.7, 196.7], [268.7, 197.0], [267.43, 197.0], [267.42, 196.7], [268.7, 196.7]]]}	-3.11	11	\N	\N
+82	{"type": "Polygon", "coordinates": [[[268.7, 197.0], [268.71, 197.3], [267.43, 197.3], [267.43, 197.0], [268.7, 197.0]]]}	-2.95	11	\N	\N
+28	{"type": "Polygon", "coordinates": [[[267.42, 196.7], [267.42, 196.4], [268.69, 196.4], [268.69, 196.7], [267.42, 196.7]]]}	-6.05	77	\N	\N
+29	{"type": "Polygon", "coordinates": [[[268.69, 196.7], [268.69, 197.0], [267.43, 197.0], [267.42, 196.7], [268.69, 196.7]]]}	-5.88	77	\N	\N
+30	{"type": "Polygon", "coordinates": [[[267.43, 197.3], [267.43, 197.0], [268.69, 197.0], [268.69, 197.3], [267.43, 197.3]]]}	-5.72	77	\N	\N
+32	{"type": "Polygon", "coordinates": [[[267.43, 197.9], [267.43, 197.6], [268.69, 197.6], [268.69, 197.9], [267.43, 197.9]]]}	-5.39	77	\N	\N
+31	{"type": "Polygon", "coordinates": [[[267.43, 197.6], [267.43, 197.3], [268.69, 197.3], [268.69, 197.6], [267.43, 197.6]]]}	-5.56	77	\N	\N
+16	{"type": "Polygon", "coordinates": [[[267.42, 196.4], [267.42, 196.11], [268.69, 196.11], [268.69, 196.4], [267.42, 196.4]]]}	-6.21	77	\N	\N
+144	{"type": "MultiPolygon", "coordinates": [[[[342.75, 207.6], [342.86, 207.6], [342.86, 206.24], [342.75, 206.24], [342.75, 207.6]]], [[[423.79, 206.54], [423.63, 206.54], [423.63, 207.68], [423.79, 207.68], [423.79, 206.54]]]]}	3.87	85	\N	\N
+77	{"type": "Polygon", "coordinates": [[[267.42, 196.1], [267.42, 195.86], [268.7, 195.86], [268.7, 196.1], [267.42, 196.1]]]}	-3.60	11	\N	\N
+105	{"type": "MultiPolygon", "coordinates": [[[[342.75, 207.6], [342.88, 207.6], [342.88, 206.24], [342.75, 206.24], [342.75, 207.6]]], [[[422.69, 206.43], [422.6, 206.43], [422.6, 207.68], [422.69, 207.68], [422.69, 206.43]]]]}	9.05	82	\N	\N
+176	{"type": "Polygon", "coordinates": [[[277.62, 142.09], [277.59, 142.39], [276.64, 142.29], [276.67, 142.0], [277.62, 142.09]]]}	1.00	11	\N	\N
 185	{"type": "Polygon", "coordinates": [[[276.87, 139.85], [276.9, 139.57], [277.85, 139.66], [277.82, 139.94], [276.87, 139.85]]]}	-0.75	11	\N	\N
 187	{"type": "Polygon", "coordinates": [[[276.97, 138.77], [277.0, 138.49], [277.95, 138.59], [277.93, 138.86], [276.97, 138.77]]]}	-1.75	11	\N	\N
 183	{"type": "Polygon", "coordinates": [[[276.72, 141.46], [276.75, 141.18], [277.7, 141.28], [277.67, 141.55], [276.72, 141.46]]]}	0.25	11	\N	\N
@@ -3553,19 +3593,10 @@ COPY public.mapdata_altitudearea (id, geometry, altitude, level_id, import_tag, 
 177	{"type": "Polygon", "coordinates": [[[277.88, 139.39], [277.85, 139.66], [276.9, 139.57], [276.92, 139.3], [277.88, 139.39]]]}	-1.00	11	\N	\N
 186	{"type": "Polygon", "coordinates": [[[276.92, 139.3], [276.95, 139.03], [277.9, 139.12], [277.88, 139.39], [276.92, 139.3]]]}	-1.25	11	\N	\N
 178	{"type": "Polygon", "coordinates": [[[277.67, 141.55], [277.64, 141.82], [276.69, 141.73], [276.72, 141.46], [277.67, 141.55]]]}	0.50	11	\N	\N
-27	{"type": "Polygon", "coordinates": [[[270.36, 198.2], [270.36, 199.3], [267.44, 199.29], [267.43, 197.9], [268.69, 197.9], [268.69, 198.23], [268.7, 198.23], [268.93, 198.23], [268.96, 198.23], [268.96, 198.2], [270.36, 198.2]]]}	-5.23	77	\N	\N
-315	{"type": "MultiPolygon", "coordinates": [[[[248.95, 137.15], [249.3, 133.35], [249.04, 133.32], [248.66, 137.4], [252.61, 137.77], [252.63, 137.5], [248.95, 137.15]]], [[[269.79, 139.07], [258.4, 138.01], [258.38, 138.29], [269.76, 139.33], [269.79, 139.07]]], [[[274.13, 140.47], [276.53, 140.7], [276.56, 140.42], [274.15, 140.19], [274.13, 140.47]]]]}	0.67	2	\N	\N
-158	{"type": "MultiPolygon", "coordinates": [[[[341.17, 206.23], [340.85, 206.23], [340.85, 207.6], [341.17, 207.6], [341.17, 206.23]]], [[[425.07, 206.55], [424.86, 206.55], [424.86, 207.68], [425.07, 207.68], [425.07, 206.55]]]]}	2.65	85	\N	\N
-163	{"type": "MultiPolygon", "coordinates": [[[[342.75, 206.24], [342.43, 206.24], [342.43, 207.6], [342.75, 207.6], [342.75, 206.24]]], [[[424.0, 206.54], [423.79, 206.54], [423.79, 207.68], [424.0, 207.68], [424.0, 206.54]]]]}	3.67	85	\N	\N
-243	{"type": "Polygon", "coordinates": [[[269.31, 231.89], [269.03, 231.89], [269.03, 230.31], [269.31, 230.31], [269.31, 231.89]]]}	6.67	82	\N	\N
-193	{"type": "Polygon", "coordinates": [[[270.71, 231.89], [270.43, 231.89], [270.43, 230.31], [270.71, 230.31], [270.71, 231.89]]]}	-3.70	11	\N	\N
-191	{"type": "Polygon", "coordinates": [[[270.15, 231.89], [269.87, 231.89], [269.87, 230.31], [270.15, 230.31], [270.15, 231.89]]]}	-3.33	11	\N	\N
-189	{"type": "Polygon", "coordinates": [[[269.59, 231.89], [269.31, 231.89], [269.31, 230.31], [269.59, 230.31], [269.59, 231.89]]]}	-2.96	11	\N	\N
-225	{"type": "Polygon", "coordinates": [[[272.39, 231.89], [272.11, 231.89], [272.11, 230.31], [272.39, 230.31], [272.39, 231.89]]]}	0.17	85	\N	\N
-223	{"type": "Polygon", "coordinates": [[[271.83, 231.89], [271.55, 231.89], [271.55, 230.31], [271.83, 230.31], [271.83, 231.89]]]}	0.51	85	\N	\N
-221	{"type": "Polygon", "coordinates": [[[271.27, 231.89], [270.99, 231.89], [270.99, 230.31], [271.27, 230.31], [271.27, 231.89]]]}	0.85	85	\N	\N
-220	{"type": "Polygon", "coordinates": [[[270.71, 231.89], [270.43, 231.89], [270.43, 230.31], [270.71, 230.31], [270.71, 231.89]]]}	1.19	85	\N	\N
-218	{"type": "Polygon", "coordinates": [[[270.15, 231.89], [269.87, 231.89], [269.87, 230.31], [270.15, 230.31], [270.15, 231.89]]]}	1.53	85	\N	\N
+182	{"type": "Polygon", "coordinates": [[[276.67, 142.0], [276.69, 141.73], [277.64, 141.82], [277.62, 142.09], [276.67, 142.0]]]}	0.75	11	\N	\N
+180	{"type": "Polygon", "coordinates": [[[277.93, 138.86], [277.9, 139.12], [276.95, 139.03], [276.97, 138.77], [277.93, 138.86]]]}	-1.50	11	\N	\N
+215	{"type": "Polygon", "coordinates": [[[272.67, 232.33], [272.73, 232.33], [272.74, 233.92], [272.67, 233.92], [272.67, 232.33]]]}	4.60	85	\N	\N
+242	{"type": "Polygon", "coordinates": [[[272.67, 232.33], [272.73, 232.33], [272.74, 233.92], [272.67, 233.92], [272.67, 232.33]]]}	9.25	82	\N	\N
 \.
 
 
@@ -4714,7 +4745,6 @@ COPY public.mapdata_locationslug (id, slug) FROM stdin;
 104	a1f1corridor
 105	a1f2corridor
 27	sem1
-106	presidentoffice
 107	a1stairsb12
 8	wc-for-women
 5	a1el2
@@ -4786,6 +4816,8 @@ COPY public.mapdata_locationslug (id, slug) FROM stdin;
 151	\N
 45	a2f2corridor
 88	a2f1elev
+153	\N
+106	presidentoffice
 \.
 
 
@@ -4794,1619 +4826,1625 @@ COPY public.mapdata_locationslug (id, slug) FROM stdin;
 --
 
 COPY public.mapdata_mapupdate (id, datetime, type, processed, geometries_changed, user_id) FROM stdin;
-210	2024-08-26 18:29:07.884+02	direct_edit	t	t	1
-209	2024-08-26 18:28:00.699+02	direct_edit	t	t	1
-211	2024-08-27 12:08:59.004972+02	management	t	f	\N
-212	2024-08-27 12:09:19.465461+02	management	t	f	\N
-213	2024-08-27 12:13:53.88039+02	direct_edit	t	f	1
-214	2024-08-27 12:14:57.981204+02	direct_edit	t	f	1
-215	2024-08-27 12:19:11.329148+02	direct_edit	t	t	1
-217	2024-08-29 11:18:33.55282+02	control_panel	t	t	1
-216	2024-08-29 11:13:55.910267+02	direct_edit	t	t	1
-224	2024-08-29 11:26:25.481507+02	direct_edit	t	t	1
-223	2024-08-29 11:25:13.004416+02	direct_edit	t	f	1
-222	2024-08-29 11:25:05.815454+02	direct_edit	t	t	1
-221	2024-08-29 11:24:38.776899+02	direct_edit	t	t	1
-220	2024-08-29 11:24:04.990566+02	direct_edit	t	t	1
-219	2024-08-29 11:23:11.100271+02	direct_edit	t	f	1
-218	2024-08-29 11:21:00.436979+02	direct_edit	t	f	1
-226	2024-08-29 11:28:42.264428+02	direct_edit	t	t	1
-225	2024-08-29 11:28:04.595118+02	direct_edit	t	t	1
-228	2024-08-29 11:30:34.905809+02	direct_edit	t	t	1
-227	2024-08-29 11:29:52.750463+02	direct_edit	t	t	1
-230	2024-08-29 11:33:17.930903+02	direct_edit	t	t	1
-229	2024-08-29 11:32:58.921582+02	direct_edit	t	t	1
-233	2024-08-29 11:35:39.654214+02	direct_edit	t	t	1
-232	2024-08-29 11:35:16.548169+02	direct_edit	t	t	1
-231	2024-08-29 11:34:20.803056+02	direct_edit	t	t	1
-238	2024-08-29 11:39:04.878827+02	direct_edit	t	t	1
-237	2024-08-29 11:38:39.870322+02	direct_edit	t	f	1
-236	2024-08-29 11:38:14.712598+02	direct_edit	t	t	1
-235	2024-08-29 11:37:48.887054+02	direct_edit	t	t	1
-234	2024-08-29 11:37:25.335645+02	direct_edit	t	t	1
-241	2024-08-29 11:41:22.091492+02	direct_edit	t	f	1
-240	2024-08-29 11:41:09.392881+02	direct_edit	t	f	1
-239	2024-08-29 11:40:47.681107+02	direct_edit	t	f	1
-243	2024-08-29 11:43:06.952599+02	direct_edit	t	f	1
-242	2024-08-29 11:42:42.579501+02	direct_edit	t	f	1
-248	2024-08-29 11:50:43.687998+02	direct_edit	t	f	1
-247	2024-08-29 11:49:54.703769+02	direct_edit	t	t	1
-246	2024-08-29 11:45:51.81963+02	direct_edit	t	t	1
-245	2024-08-29 11:45:43.221388+02	direct_edit	t	t	1
-244	2024-08-29 11:44:03.545467+02	direct_edit	t	f	1
-250	2024-08-29 11:52:50.042778+02	direct_edit	t	t	1
-249	2024-08-29 11:52:07.250959+02	direct_edit	t	f	1
-252	2024-08-29 11:56:04.807276+02	direct_edit	t	t	1
-251	2024-08-29 11:55:11.149843+02	direct_edit	t	t	1
-253	2024-08-29 11:58:45.59235+02	direct_edit	t	t	1
-263	2024-08-29 12:10:13.499096+02	direct_edit	t	f	1
-262	2024-08-29 12:09:58.138119+02	direct_edit	t	f	1
-261	2024-08-29 12:09:50.15106+02	direct_edit	t	f	1
-260	2024-08-29 12:09:28.440383+02	direct_edit	t	f	1
-259	2024-08-29 12:08:52.800394+02	direct_edit	t	t	1
-258	2024-08-29 12:03:57.066581+02	direct_edit	t	t	1
-257	2024-08-29 12:03:33.10395+02	direct_edit	t	t	1
-256	2024-08-29 12:03:16.565277+02	direct_edit	t	t	1
-255	2024-08-29 12:02:57.69302+02	direct_edit	t	t	1
-254	2024-08-29 12:02:38.237035+02	direct_edit	t	t	1
-274	2024-08-29 12:25:28.979404+02	direct_edit	t	f	1
-273	2024-08-29 12:25:22.62013+02	direct_edit	t	f	1
-272	2024-08-29 12:24:57.442782+02	direct_edit	t	f	1
-271	2024-08-29 12:24:50.46408+02	direct_edit	t	f	1
-270	2024-08-29 12:24:11.962458+02	direct_edit	t	t	1
-269	2024-08-29 12:23:46.154768+02	direct_edit	t	t	1
-268	2024-08-29 12:23:38.376962+02	direct_edit	t	t	1
-267	2024-08-29 12:23:25.265377+02	direct_edit	t	t	1
-266	2024-08-29 12:23:09.084656+02	direct_edit	t	t	1
-265	2024-08-29 12:23:04.380568+02	direct_edit	t	t	1
-264	2024-08-29 12:22:53.13712+02	direct_edit	t	t	1
-275	2024-08-29 12:28:18.446324+02	direct_edit	t	f	1
-282	2024-08-29 12:49:43.078575+02	direct_edit	t	f	1
-281	2024-08-29 12:49:37.142884+02	direct_edit	t	f	1
-280	2024-08-29 12:49:31.622177+02	direct_edit	t	f	1
-279	2024-08-29 12:49:23.006829+02	direct_edit	t	f	1
-278	2024-08-29 12:49:16.448651+02	direct_edit	t	f	1
-277	2024-08-29 12:49:08.6712+02	direct_edit	t	f	1
-276	2024-08-29 12:48:39.777997+02	direct_edit	t	f	1
-283	2024-08-29 12:51:13.586654+02	direct_edit	t	f	1
-284	2024-08-29 12:54:27.127752+02	direct_edit	t	f	1
-285	2024-09-04 16:17:36.439755+02	direct_edit	t	t	1
-291	2024-09-06 09:49:06.147603+02	direct_edit	t	t	1
-290	2024-09-06 09:48:02.455722+02	direct_edit	t	t	1
-289	2024-09-06 09:47:54.260887+02	direct_edit	t	t	1
-288	2024-09-06 09:47:45.454026+02	direct_edit	t	t	1
-287	2024-09-06 09:47:33.783657+02	direct_edit	t	t	1
-286	2024-09-06 09:47:16.576667+02	direct_edit	t	t	1
-292	2024-09-06 09:50:25.234843+02	direct_edit	t	t	1
-302	2024-09-06 17:28:30.847255+02	direct_edit	t	t	1
-301	2024-09-06 17:27:17.120685+02	direct_edit	t	t	1
-300	2024-09-06 17:27:07.071526+02	direct_edit	t	f	1
-299	2024-09-06 17:26:38.412071+02	direct_edit	t	t	1
-298	2024-09-06 17:26:20.069538+02	direct_edit	t	f	1
-297	2024-09-06 17:25:42.704835+02	direct_edit	t	t	1
-296	2024-09-06 17:25:12.19151+02	direct_edit	t	f	1
-295	2024-09-06 17:25:01.734519+02	direct_edit	t	f	1
-294	2024-09-06 17:23:15.453189+02	direct_edit	t	t	1
-293	2024-09-06 17:23:07.672316+02	direct_edit	t	t	1
-1451	2024-09-17 11:58:51.286769+02	direct_edit	t	t	1
-1463	2024-09-24 12:04:34.216787+02	management	t	t	\N
-343	2024-09-06 17:45:12.369938+02	direct_edit	t	t	1
-342	2024-09-06 17:44:39.977339+02	direct_edit	t	t	1
-341	2024-09-06 17:43:49.834548+02	direct_edit	t	t	1
-340	2024-09-06 17:41:42.21649+02	direct_edit	t	f	1
-339	2024-09-06 17:41:39.146591+02	direct_edit	t	f	1
-338	2024-09-06 17:41:35.192818+02	direct_edit	t	f	1
-337	2024-09-06 17:41:28.49275+02	direct_edit	t	f	1
-336	2024-09-06 17:40:55.116517+02	direct_edit	t	f	1
-335	2024-09-06 17:40:52.249014+02	direct_edit	t	f	1
-334	2024-09-06 17:40:46.721944+02	direct_edit	t	f	1
-333	2024-09-06 17:40:39.957981+02	direct_edit	t	f	1
-332	2024-09-06 17:40:34.017518+02	direct_edit	t	f	1
-331	2024-09-06 17:40:29.918907+02	direct_edit	t	f	1
-330	2024-09-06 17:40:25.412466+02	direct_edit	t	f	1
-329	2024-09-06 17:40:07.586805+02	direct_edit	t	t	1
-328	2024-09-06 17:39:58.370542+02	direct_edit	t	t	1
-327	2024-09-06 17:39:51.615625+02	direct_edit	t	t	1
-326	2024-09-06 17:39:44.252296+02	direct_edit	t	t	1
-325	2024-09-06 17:39:36.05012+02	direct_edit	t	t	1
-324	2024-09-06 17:39:28.67254+02	direct_edit	t	t	1
-323	2024-09-06 17:39:20.688748+02	direct_edit	t	t	1
-322	2024-09-06 17:39:12.4951+02	direct_edit	t	t	1
-321	2024-09-06 17:39:05.125222+02	direct_edit	t	t	1
-320	2024-09-06 17:38:58.978201+02	direct_edit	t	t	1
-319	2024-09-06 17:38:52.424022+02	direct_edit	t	t	1
-318	2024-09-06 17:38:45.25631+02	direct_edit	t	t	1
-317	2024-09-06 17:38:37.47802+02	direct_edit	t	t	1
-316	2024-09-06 17:38:30.719377+02	direct_edit	t	t	1
-315	2024-09-06 17:38:23.554845+02	direct_edit	t	t	1
-314	2024-09-06 17:38:16.584641+02	direct_edit	t	t	1
-313	2024-09-06 17:37:58.567224+02	direct_edit	t	t	1
-312	2024-09-06 17:37:42.597163+02	direct_edit	t	t	1
-311	2024-09-06 17:37:27.229276+02	direct_edit	t	t	1
-310	2024-09-06 17:37:17.406104+02	direct_edit	t	t	1
-309	2024-09-06 17:36:49.97444+02	direct_edit	t	t	1
-308	2024-09-06 17:35:20.876125+02	direct_edit	t	f	1
-307	2024-09-06 17:32:59.171721+02	direct_edit	t	t	1
-306	2024-09-06 17:32:43.78461+02	direct_edit	t	t	1
-305	2024-09-06 17:32:28.731979+02	direct_edit	t	t	1
-304	2024-09-06 17:32:06.937298+02	direct_edit	t	f	1
-303	2024-09-06 17:31:16.321467+02	direct_edit	t	f	1
-345	2024-09-06 17:50:36.751498+02	direct_edit	t	f	1
-344	2024-09-06 17:50:01.149004+02	direct_edit	t	t	1
-352	2024-09-07 15:43:01.626708+02	direct_edit	t	f	1
-351	2024-09-07 15:42:57.534366+02	direct_edit	t	f	1
-350	2024-09-07 15:42:48.31167+02	direct_edit	t	f	1
-349	2024-09-07 15:42:42.988137+02	direct_edit	t	t	1
-348	2024-09-07 15:42:29.676839+02	direct_edit	t	t	1
-347	2024-09-07 15:42:22.290238+02	direct_edit	t	f	1
-346	2024-09-07 15:41:57.104812+02	direct_edit	t	t	1
-359	2024-09-07 15:45:13.724763+02	direct_edit	t	f	1
-358	2024-09-07 15:45:11.879539+02	direct_edit	t	f	1
-357	2024-09-07 15:45:10.0371+02	direct_edit	t	f	1
-356	2024-09-07 15:45:02.871721+02	direct_edit	t	f	1
-355	2024-09-07 15:44:59.794215+02	direct_edit	t	f	1
-354	2024-09-07 15:44:48.941889+02	direct_edit	t	t	1
-353	2024-09-07 15:44:40.756985+02	direct_edit	t	f	1
-360	2024-09-07 15:46:44.063729+02	direct_edit	t	t	1
-361	2024-09-07 15:48:12.30391+02	direct_edit	t	t	1
-362	2024-09-07 15:49:23.4101+02	direct_edit	t	t	1
-381	2024-09-07 17:20:12.780091+02	direct_edit	t	f	1
-380	2024-09-07 17:20:01.312732+02	direct_edit	t	f	1
-379	2024-09-07 17:19:57.622271+02	direct_edit	t	f	1
-378	2024-09-07 17:19:44.30942+02	direct_edit	t	f	1
-377	2024-09-07 17:19:28.943039+02	direct_edit	t	f	1
-376	2024-09-07 17:17:29.760583+02	direct_edit	t	f	1
-375	2024-09-07 17:17:26.282425+02	direct_edit	t	f	1
-374	2024-09-07 17:17:21.766637+02	direct_edit	t	f	1
-373	2024-09-07 17:17:14.193557+02	direct_edit	t	f	1
-372	2024-09-07 17:16:49.208231+02	direct_edit	t	f	1
-371	2024-09-07 17:16:44.701281+02	direct_edit	t	f	1
-370	2024-09-07 17:16:36.505509+02	direct_edit	t	f	1
-369	2024-09-07 17:16:19.924697+02	direct_edit	t	f	1
-368	2024-09-07 17:15:55.34475+02	direct_edit	t	f	1
-367	2024-09-07 17:15:44.920176+02	direct_edit	t	f	1
-366	2024-09-07 17:14:55.7438+02	direct_edit	t	t	1
-365	2024-09-07 17:14:15.073165+02	direct_edit	t	t	1
-364	2024-09-07 17:14:00.6651+02	direct_edit	t	t	1
-363	2024-09-07 17:12:46.537393+02	direct_edit	t	t	1
-382	2024-09-07 17:24:48.242937+02	direct_edit	t	t	1
-383	2024-09-08 15:04:23.072218+02	direct_edit	t	f	1
-384	2024-09-08 15:14:51.180815+02	direct_edit	t	f	1
-385	2024-09-08 15:15:09.849713+02	management	t	f	\N
-386	2024-09-08 15:16:15.996417+02	direct_edit	t	t	1
-393	2024-09-08 15:21:59.630012+02	direct_edit	t	t	1
-392	2024-09-08 15:21:33.834162+02	direct_edit	t	t	1
-391	2024-09-08 15:20:53.916275+02	direct_edit	t	t	1
-390	2024-09-08 15:19:34.427024+02	direct_edit	t	t	1
-389	2024-09-08 15:19:30.126553+02	direct_edit	t	t	1
-388	2024-09-08 15:19:26.241253+02	direct_edit	t	t	1
-387	2024-09-08 15:19:21.730552+02	direct_edit	t	t	1
-397	2024-09-08 15:31:06.252171+02	direct_edit	t	t	1
-396	2024-09-08 15:30:22.245382+02	direct_edit	t	t	1
-395	2024-09-08 15:28:23.668135+02	direct_edit	t	t	1
-394	2024-09-08 15:26:31.02319+02	direct_edit	t	t	1
-404	2024-09-08 15:40:14.331678+02	direct_edit	t	f	1
-403	2024-09-08 15:39:39.482799+02	direct_edit	t	t	1
-402	2024-09-08 15:39:13.094796+02	direct_edit	t	t	1
-401	2024-09-08 15:38:12.688373+02	direct_edit	t	t	1
-400	2024-09-08 15:33:14.247243+02	direct_edit	t	t	1
-399	2024-09-08 15:32:36.363492+02	direct_edit	t	f	1
-398	2024-09-08 15:32:30.633935+02	direct_edit	t	t	1
-405	2024-09-08 15:40:53.892833+02	management	t	f	\N
-406	2024-09-08 15:44:43.245159+02	management	t	f	\N
-408	2024-09-08 16:01:34.830472+02	management	t	f	\N
-407	2024-09-08 16:01:23.061072+02	direct_edit	t	t	1
-410	2024-09-08 16:04:15.562542+02	management	t	f	\N
-409	2024-09-08 16:04:03.248852+02	direct_edit	t	t	1
-412	2024-09-08 16:06:05.753489+02	management	t	f	\N
-411	2024-09-08 16:05:32.747845+02	direct_edit	t	t	1
-414	2024-09-08 16:07:55.085302+02	direct_edit	t	t	1
-413	2024-09-08 16:07:10.447539+02	direct_edit	t	t	1
-415	2024-09-08 16:09:40.963861+02	direct_edit	t	t	1
-416	2024-09-08 16:13:20.719936+02	direct_edit	t	t	1
-419	2024-09-08 16:16:06.405037+02	direct_edit	t	t	1
-418	2024-09-08 16:15:40.775285+02	direct_edit	t	t	1
-417	2024-09-08 16:15:03.119899+02	direct_edit	t	t	1
-420	2024-09-08 16:17:05.617823+02	management	t	f	\N
-422	2024-09-09 08:37:17.566215+02	direct_edit	t	t	1
-421	2024-09-09 08:36:57.6649+02	direct_edit	t	t	1
-428	2024-09-09 08:46:05.994759+02	management	t	f	\N
-427	2024-09-09 08:44:29.459471+02	direct_edit	t	t	1
-426	2024-09-09 08:44:20.049891+02	direct_edit	t	t	1
-425	2024-09-09 08:44:15.327053+02	direct_edit	t	t	1
-424	2024-09-09 08:44:02.22251+02	direct_edit	t	t	1
-423	2024-09-09 08:43:54.850252+02	direct_edit	t	t	1
-429	2024-09-09 08:47:55.518215+02	management	t	f	\N
-430	2024-09-09 08:49:19.705936+02	direct_edit	t	t	1
-431	2024-09-09 08:51:46.579894+02	management	t	f	\N
-434	2024-09-09 08:53:44.896137+02	direct_edit	t	t	1
-433	2024-09-09 08:53:35.67678+02	direct_edit	t	t	1
-432	2024-09-09 08:53:20.752247+02	direct_edit	t	t	1
-435	2024-09-09 08:56:19.959336+02	direct_edit	t	t	1
-442	2024-09-09 09:25:29.971686+02	direct_edit	t	t	1
-441	2024-09-09 09:24:59.279486+02	direct_edit	t	t	1
-440	2024-09-09 09:24:24.263241+02	direct_edit	t	t	1
-439	2024-09-09 09:23:52.68741+02	direct_edit	t	t	1
-438	2024-09-09 09:23:17.474656+02	direct_edit	t	t	1
-437	2024-09-09 09:22:07.631007+02	direct_edit	t	t	1
-436	2024-09-09 09:20:46.323148+02	direct_edit	t	t	1
-444	2024-09-09 09:27:42.479752+02	direct_edit	t	t	1
-443	2024-09-09 09:26:57.015816+02	direct_edit	t	t	1
-452	2024-09-09 09:31:34.524747+02	direct_edit	t	f	1
-451	2024-09-09 09:31:25.920365+02	direct_edit	t	f	1
-450	2024-09-09 09:30:46.398787+02	direct_edit	t	f	1
-449	2024-09-09 09:30:31.45453+02	direct_edit	t	f	1
-448	2024-09-09 09:30:26.742663+02	direct_edit	t	f	1
-447	2024-09-09 09:30:08.710049+02	direct_edit	t	f	1
-446	2024-09-09 09:30:04.660181+02	direct_edit	t	f	1
-445	2024-09-09 09:29:42.502925+02	direct_edit	t	t	1
-453	2024-09-09 09:33:19.990441+02	direct_edit	t	f	1
-454	2024-09-09 09:38:05.891486+02	direct_edit	t	f	1
-457	2024-09-09 09:41:53.062925+02	direct_edit	t	f	1
-456	2024-09-09 09:41:43.840339+02	direct_edit	t	f	1
-455	2024-09-09 09:41:32.580453+02	direct_edit	t	t	1
-459	2024-09-09 09:45:18.448552+02	direct_edit	t	f	1
-458	2024-09-09 09:45:05.797165+02	direct_edit	t	f	1
-462	2024-09-09 09:56:38.643113+02	management	t	f	\N
-461	2024-09-09 09:55:27.942423+02	direct_edit	t	t	1
-460	2024-09-09 09:55:19.551465+02	direct_edit	t	t	1
-466	2024-09-09 10:00:06.483721+02	direct_edit	t	f	1
-465	2024-09-09 09:59:54.601331+02	direct_edit	t	f	1
-464	2024-09-09 09:59:28.790191+02	direct_edit	t	f	1
-463	2024-09-09 09:57:29.873802+02	direct_edit	t	t	1
-468	2024-09-09 10:02:46.83677+02	direct_edit	t	f	1
-467	2024-09-09 10:02:35.782532+02	direct_edit	t	f	1
-469	2024-09-09 10:04:04.461798+02	direct_edit	t	f	1
-470	2024-09-09 10:04:19.910271+02	management	t	f	\N
-473	2024-09-09 10:07:16.244106+02	management	t	f	\N
-472	2024-09-09 10:06:46.052174+02	direct_edit	t	f	1
-471	2024-09-09 10:06:41.541636+02	direct_edit	t	f	1
-477	2024-09-09 10:16:12.052682+02	direct_edit	t	f	1
-476	2024-09-09 10:16:03.111476+02	direct_edit	t	f	1
-475	2024-09-09 10:15:53.284379+02	direct_edit	t	f	1
-474	2024-09-09 10:10:37.274052+02	direct_edit	t	t	1
-478	2024-09-09 10:19:10.094147+02	direct_edit	t	t	1
-485	2024-09-09 10:37:42.05259+02	management	t	f	\N
-484	2024-09-09 10:36:37.475212+02	direct_edit	t	t	1
-483	2024-09-09 10:35:27.65272+02	direct_edit	t	t	1
-482	2024-09-09 10:34:45.671364+02	direct_edit	t	t	1
-481	2024-09-09 10:34:07.579557+02	direct_edit	t	t	1
-480	2024-09-09 10:32:52.955664+02	direct_edit	t	t	1
-479	2024-09-09 10:31:10.824543+02	direct_edit	t	t	1
-487	2024-09-09 10:39:44.509942+02	management	t	f	\N
-486	2024-09-09 10:39:09.27074+02	direct_edit	t	t	1
-489	2024-09-09 10:41:34.626938+02	direct_edit	t	t	1
-488	2024-09-09 10:41:14.003561+02	direct_edit	t	t	1
-496	2024-09-09 10:54:47.832929+02	direct_edit	t	t	1
-495	2024-09-09 10:54:40.051725+02	direct_edit	t	t	1
-494	2024-09-09 10:54:18.534587+02	direct_edit	t	f	1
-493	2024-09-09 10:54:08.703531+02	direct_edit	t	f	1
-492	2024-09-09 10:52:59.117547+02	direct_edit	t	t	1
-491	2024-09-09 10:49:56.831755+02	direct_edit	t	t	1
-490	2024-09-09 10:46:58.644834+02	direct_edit	t	f	1
-501	2024-09-09 11:03:24.045831+02	management	t	f	\N
-500	2024-09-09 11:02:19.64621+02	direct_edit	t	t	1
-499	2024-09-09 11:01:08.354748+02	direct_edit	t	t	1
-498	2024-09-09 11:00:55.251079+02	direct_edit	t	t	1
-497	2024-09-09 11:00:30.296998+02	direct_edit	t	t	1
-510	2024-09-09 11:08:37.427351+02	management	t	f	\N
-509	2024-09-09 11:07:59.805377+02	direct_edit	t	t	1
-508	2024-09-09 11:07:52.025037+02	direct_edit	t	t	1
-507	2024-09-09 11:07:24.783785+02	direct_edit	t	t	1
-506	2024-09-09 11:07:09.426652+02	direct_edit	t	t	1
-505	2024-09-09 11:06:27.852913+02	direct_edit	t	t	1
-504	2024-09-09 11:06:09.011879+02	direct_edit	t	t	1
-503	2024-09-09 11:06:04.296966+02	direct_edit	t	t	1
-502	2024-09-09 11:05:54.878263+02	direct_edit	t	t	1
-518	2024-09-09 13:57:25.073455+02	management	t	f	\N
-517	2024-09-09 13:26:58.990248+02	direct_edit	t	t	1
-516	2024-09-09 13:26:46.299127+02	direct_edit	t	t	1
-515	2024-09-09 13:26:06.77042+02	direct_edit	t	t	1
-514	2024-09-09 13:25:49.766881+02	direct_edit	t	t	1
-513	2024-09-09 13:25:36.250635+02	direct_edit	t	t	1
-512	2024-09-09 13:25:05.939145+02	direct_edit	t	t	1
-511	2024-09-09 13:24:36.066279+02	direct_edit	t	t	1
-1453	2024-09-17 12:00:13.823186+02	direct_edit	t	t	1
-527	2024-09-09 14:00:51.062797+02	direct_edit	t	f	1
-526	2024-09-09 14:00:45.735306+02	direct_edit	t	f	1
-525	2024-09-09 14:00:42.260665+02	direct_edit	t	f	1
-524	2024-09-09 14:00:28.937938+02	direct_edit	t	f	1
-523	2024-09-09 14:00:24.22382+02	direct_edit	t	f	1
-522	2024-09-09 14:00:12.344409+02	direct_edit	t	f	1
-521	2024-09-09 13:59:42.466064+02	direct_edit	t	f	1
-520	2024-09-09 13:59:23.022119+02	direct_edit	t	t	1
-519	2024-09-09 13:58:34.450776+02	direct_edit	t	t	1
-531	2024-09-09 14:03:37.550135+02	direct_edit	t	t	1
-530	2024-09-09 14:03:24.238836+02	direct_edit	t	t	1
-529	2024-09-09 14:03:06.217063+02	direct_edit	t	t	1
-528	2024-09-09 14:02:54.135449+02	direct_edit	t	t	1
-544	2024-09-09 14:06:15.055296+02	direct_edit	t	f	1
-543	2024-09-09 14:06:12.187204+02	direct_edit	t	f	1
-542	2024-09-09 14:06:01.745036+02	direct_edit	t	f	1
-541	2024-09-09 14:05:59.494049+02	direct_edit	t	f	1
-540	2024-09-09 14:05:54.980294+02	direct_edit	t	f	1
-539	2024-09-09 14:05:51.708362+02	direct_edit	t	f	1
-538	2024-09-09 14:05:41.886527+02	direct_edit	t	f	1
-537	2024-09-09 14:05:39.213338+02	direct_edit	t	f	1
-536	2024-09-09 14:05:31.633572+02	direct_edit	t	f	1
-535	2024-09-09 14:05:29.793947+02	direct_edit	t	f	1
-534	2024-09-09 14:05:21.807729+02	direct_edit	t	f	1
-533	2024-09-09 14:05:15.66883+02	direct_edit	t	f	1
-532	2024-09-09 14:05:13.616362+02	direct_edit	t	f	1
-549	2024-09-09 14:08:20.195811+02	direct_edit	t	f	1
-548	2024-09-09 14:08:17.121137+02	direct_edit	t	f	1
-547	2024-09-09 14:08:14.455351+02	direct_edit	t	f	1
-546	2024-09-09 14:08:07.905102+02	direct_edit	t	f	1
-545	2024-09-09 14:07:59.918561+02	direct_edit	t	f	1
-550	2024-09-09 14:10:02.798039+02	direct_edit	t	f	1
-554	2024-09-09 14:33:11.19119+02	direct_edit	t	t	1
-553	2024-09-09 14:15:22.295487+02	direct_edit	t	f	1
-552	2024-09-09 14:13:40.28748+02	direct_edit	t	t	1
-551	2024-09-09 14:13:30.047792+02	direct_edit	t	t	1
-555	2024-09-09 14:34:49.699096+02	direct_edit	t	t	1
-566	2024-09-09 14:39:29.031929+02	direct_edit	t	f	1
-565	2024-09-09 14:39:21.850678+02	direct_edit	t	f	1
-564	2024-09-09 14:38:45.407038+02	direct_edit	t	f	1
-563	2024-09-09 14:38:38.433731+02	direct_edit	t	f	1
-562	2024-09-09 14:38:21.638096+02	direct_edit	t	f	1
-561	2024-09-09 14:38:04.024341+02	direct_edit	t	t	1
-560	2024-09-09 14:37:55.630884+02	direct_edit	t	t	1
-559	2024-09-09 14:37:40.675049+02	direct_edit	t	t	1
-558	2024-09-09 14:37:36.168929+02	direct_edit	t	t	1
-557	2024-09-09 14:37:31.665195+02	direct_edit	t	t	1
-556	2024-09-09 14:37:27.243943+02	direct_edit	t	t	1
-567	2024-09-09 14:41:56.070963+02	direct_edit	t	f	1
-568	2024-09-09 14:43:44.826086+02	direct_edit	t	f	1
-570	2024-09-09 14:48:58.986939+02	direct_edit	t	t	1
-569	2024-09-09 14:48:26.642027+02	direct_edit	t	t	1
-571	2024-09-09 14:50:13.765199+02	management	t	f	\N
-574	2024-09-09 14:55:50.305978+02	management	t	f	\N
-573	2024-09-09 14:55:14.205586+02	direct_edit	t	t	1
-572	2024-09-09 14:53:09.292181+02	direct_edit	t	t	1
-575	2024-09-09 14:57:13.966329+02	management	t	f	\N
-603	2024-09-09 15:03:45.03202+02	management	t	f	\N
-602	2024-09-09 15:03:30.849157+02	direct_edit	t	f	1
-601	2024-09-09 15:03:26.95121+02	direct_edit	t	f	1
-600	2024-09-09 15:03:24.083947+02	direct_edit	t	f	1
-599	2024-09-09 15:03:17.526609+02	direct_edit	t	f	1
-598	2024-09-09 15:03:13.840004+02	direct_edit	t	f	1
-597	2024-09-09 15:03:10.369874+02	direct_edit	t	f	1
-596	2024-09-09 15:03:01.759687+02	direct_edit	t	f	1
-595	2024-09-09 15:02:58.077408+02	direct_edit	t	f	1
-594	2024-09-09 15:02:52.12882+02	direct_edit	t	f	1
-593	2024-09-09 15:02:46.394023+02	direct_edit	t	f	1
-592	2024-09-09 15:02:27.353622+02	direct_edit	t	f	1
-591	2024-09-09 15:02:17.520558+02	direct_edit	t	f	1
-590	2024-09-09 15:02:13.420799+02	direct_edit	t	f	1
-589	2024-09-09 15:02:08.229664+02	direct_edit	t	f	1
-588	2024-09-09 15:02:04.821244+02	direct_edit	t	f	1
-587	2024-09-09 15:01:48.233024+02	direct_edit	t	f	1
-586	2024-09-09 15:01:37.170637+02	direct_edit	t	f	1
-585	2024-09-09 15:00:52.117656+02	direct_edit	t	f	1
-584	2024-09-09 15:00:46.583968+02	direct_edit	t	f	1
-583	2024-09-09 15:00:28.769765+02	direct_edit	t	f	1
-582	2024-09-09 15:00:23.854871+02	direct_edit	t	f	1
-581	2024-09-09 15:00:19.969116+02	direct_edit	t	f	1
-580	2024-09-09 15:00:14.02975+02	direct_edit	t	f	1
-579	2024-09-09 15:00:06.24147+02	direct_edit	t	f	1
-578	2024-09-09 15:00:03.170837+02	direct_edit	t	f	1
-577	2024-09-09 14:59:37.151395+02	direct_edit	t	t	1
-576	2024-09-09 14:59:10.566704+02	direct_edit	t	t	1
-607	2024-09-09 15:05:17.133838+02	direct_edit	t	f	1
-606	2024-09-09 15:05:05.46058+02	direct_edit	t	f	1
-605	2024-09-09 15:04:59.531447+02	direct_edit	t	f	1
-604	2024-09-09 15:04:53.378149+02	direct_edit	t	f	1
-608	2024-09-09 15:05:34.169905+02	management	t	f	\N
-610	2024-09-09 15:28:14.67968+02	management	t	f	\N
-609	2024-09-09 15:27:34.491531+02	direct_edit	t	f	1
-1454	2024-09-17 12:00:18.739234+02	direct_edit	t	t	1
-631	2024-09-09 15:43:49.356112+02	direct_edit	t	t	1
-630	2024-09-09 15:43:42.194974+02	direct_edit	t	t	1
-629	2024-09-09 15:43:21.295518+02	direct_edit	t	t	1
-628	2024-09-09 15:42:50.17174+02	direct_edit	t	t	1
-627	2024-09-09 15:42:30.731202+02	direct_edit	t	t	1
-626	2024-09-09 15:41:11.864986+02	direct_edit	t	t	1
-658	2024-09-09 15:48:31.172176+02	direct_edit	t	f	1
-657	2024-09-09 15:48:28.714556+02	direct_edit	t	f	1
-656	2024-09-09 15:48:25.84855+02	direct_edit	t	f	1
-655	2024-09-09 15:48:18.679285+02	direct_edit	t	f	1
-654	2024-09-09 15:48:10.284205+02	direct_edit	t	f	1
-653	2024-09-09 15:48:05.782015+02	direct_edit	t	f	1
-652	2024-09-09 15:47:56.153905+02	direct_edit	t	f	1
-651	2024-09-09 15:47:50.212298+02	direct_edit	t	f	1
-650	2024-09-09 15:47:34.43843+02	direct_edit	t	f	1
-649	2024-09-09 15:47:20.14339+02	direct_edit	t	f	1
-648	2024-09-09 15:47:13.346907+02	direct_edit	t	f	1
-647	2024-09-09 15:47:07.408202+02	direct_edit	t	f	1
-646	2024-09-09 15:46:58.400144+02	direct_edit	t	f	1
-645	2024-09-09 15:46:51.431683+02	direct_edit	t	f	1
-644	2024-09-09 15:46:48.153253+02	direct_edit	t	f	1
-643	2024-09-09 15:46:39.763655+02	direct_edit	t	f	1
-642	2024-09-09 15:46:32.998182+02	direct_edit	t	f	1
-641	2024-09-09 15:46:29.722789+02	direct_edit	t	f	1
-640	2024-09-09 15:46:16.817946+02	direct_edit	t	f	1
-639	2024-09-09 15:45:56.332285+02	direct_edit	t	t	1
-638	2024-09-09 15:45:44.250209+02	direct_edit	t	t	1
-637	2024-09-09 15:45:21.929415+02	direct_edit	t	t	1
-636	2024-09-09 15:44:57.574367+02	direct_edit	t	t	1
-635	2024-09-09 15:44:18.23462+02	direct_edit	t	t	1
-634	2024-09-09 15:44:11.476916+02	direct_edit	t	t	1
-633	2024-09-09 15:44:04.664403+02	direct_edit	t	t	1
-632	2024-09-09 15:43:56.727716+02	direct_edit	t	t	1
-625	2024-09-09 15:40:31.92791+02	direct_edit	t	t	1
-624	2024-09-09 15:40:21.068689+02	direct_edit	t	t	1
-623	2024-09-09 15:39:58.948469+02	direct_edit	t	t	1
-622	2024-09-09 15:39:47.480192+02	direct_edit	t	t	1
-621	2024-09-09 15:39:34.578118+02	direct_edit	t	t	1
-620	2024-09-09 15:39:18.194475+02	direct_edit	t	t	1
-619	2024-09-09 15:39:05.495438+02	direct_edit	t	t	1
-618	2024-09-09 15:38:48.313627+02	direct_edit	t	t	1
-617	2024-09-09 15:37:55.685618+02	direct_edit	t	t	1
-616	2024-09-09 15:36:34.581299+02	direct_edit	t	t	1
-615	2024-09-09 15:35:24.539412+02	direct_edit	t	t	1
-614	2024-09-09 15:34:47.876849+02	direct_edit	t	t	1
-613	2024-09-09 15:34:08.14431+02	direct_edit	t	t	1
-612	2024-09-09 15:33:03.473213+02	direct_edit	t	f	1
-611	2024-09-09 15:30:37.800973+02	direct_edit	t	t	1
-659	2024-09-09 15:48:58.707951+02	management	t	f	\N
-666	2024-09-09 15:51:45.35696+02	direct_edit	t	t	1
-665	2024-09-09 15:51:26.310329+02	direct_edit	t	t	1
-664	2024-09-09 15:51:12.999236+02	direct_edit	t	t	1
-663	2024-09-09 15:50:50.062646+02	direct_edit	t	t	1
-662	2024-09-09 15:50:41.254625+02	direct_edit	t	t	1
-661	2024-09-09 15:50:29.57931+02	direct_edit	t	t	1
-660	2024-09-09 15:50:15.448635+02	direct_edit	t	t	1
-687	2024-09-09 16:04:07.322115+02	direct_edit	t	t	1
-686	2024-09-09 16:03:50.324188+02	direct_edit	t	t	1
-685	2024-09-09 16:03:34.759507+02	direct_edit	t	t	1
-684	2024-09-09 16:03:12.643939+02	direct_edit	t	t	1
-683	2024-09-09 16:02:48.474875+02	direct_edit	t	t	1
-682	2024-09-09 16:02:27.173899+02	direct_edit	t	t	1
-681	2024-09-09 16:02:11.200696+02	direct_edit	t	t	1
-680	2024-09-09 16:01:55.635385+02	direct_edit	t	t	1
-679	2024-09-09 16:01:39.455646+02	direct_edit	t	t	1
-678	2024-09-09 16:01:07.508034+02	direct_edit	t	t	1
-677	2024-09-09 15:57:54.995296+02	direct_edit	t	t	1
-676	2024-09-09 15:57:45.776761+02	direct_edit	t	t	1
-675	2024-09-09 15:57:36.968439+02	direct_edit	t	t	1
-674	2024-09-09 15:57:22.839341+02	direct_edit	t	t	1
-673	2024-09-09 15:57:09.730985+02	direct_edit	t	t	1
-672	2024-09-09 15:57:00.310189+02	direct_edit	t	t	1
-671	2024-09-09 15:56:51.299095+02	direct_edit	t	t	1
-670	2024-09-09 15:56:41.468215+02	direct_edit	t	t	1
-669	2024-09-09 15:56:21.400039+02	direct_edit	t	t	1
-668	2024-09-09 15:56:03.375588+02	direct_edit	t	t	1
-667	2024-09-09 15:55:52.113989+02	direct_edit	t	t	1
-698	2024-09-09 16:15:07.441089+02	direct_edit	t	t	1
-697	2024-09-09 16:12:46.122989+02	direct_edit	t	t	1
-696	2024-09-09 16:11:59.222563+02	direct_edit	t	t	1
-695	2024-09-09 16:11:02.910211+02	direct_edit	t	t	1
-694	2024-09-09 16:10:38.946712+02	direct_edit	t	t	1
-693	2024-09-09 16:10:21.53429+02	direct_edit	t	t	1
-692	2024-09-09 16:10:07.249053+02	direct_edit	t	t	1
-691	2024-09-09 16:09:48.966391+02	direct_edit	t	t	1
-690	2024-09-09 16:09:28.28864+02	direct_edit	t	t	1
-689	2024-09-09 16:08:57.571337+02	direct_edit	t	t	1
-688	2024-09-09 16:08:42.821668+02	direct_edit	t	t	1
-1452	2024-09-17 12:00:07.681503+02	direct_edit	t	t	1
-721	2024-09-09 16:42:37.299858+02	direct_edit	t	t	1
-720	2024-09-09 16:42:26.854917+02	direct_edit	t	t	1
-719	2024-09-09 16:42:19.2775+02	direct_edit	t	t	1
-718	2024-09-09 16:41:49.860184+02	direct_edit	t	t	1
-717	2024-09-09 16:41:08.83302+02	direct_edit	t	t	1
-716	2024-09-09 16:40:55.741299+02	direct_edit	t	t	1
-715	2024-09-09 16:39:43.42214+02	direct_edit	t	t	1
-714	2024-09-09 16:39:31.546104+02	direct_edit	t	t	1
-713	2024-09-09 16:39:17.199621+02	direct_edit	t	f	1
-712	2024-09-09 16:38:26.830121+02	direct_edit	t	t	1
-711	2024-09-09 16:37:35.419623+02	direct_edit	t	t	1
-741	2024-09-09 16:46:14.812377+02	direct_edit	t	f	1
-740	2024-09-09 16:46:08.05121+02	direct_edit	t	f	1
-739	2024-09-09 16:46:01.289731+02	direct_edit	t	f	1
-738	2024-09-09 16:45:57.809232+02	direct_edit	t	f	1
-737	2024-09-09 16:45:53.508681+02	direct_edit	t	f	1
-736	2024-09-09 16:45:48.591985+02	direct_edit	t	f	1
-735	2024-09-09 16:45:37.157912+02	direct_edit	t	f	1
-734	2024-09-09 16:45:34.050797+02	direct_edit	t	f	1
-733	2024-09-09 16:45:20.326512+02	direct_edit	t	f	1
-732	2024-09-09 16:45:18.076862+02	direct_edit	t	f	1
-731	2024-09-09 16:45:14.553235+02	direct_edit	t	f	1
-730	2024-09-09 16:45:13.159283+02	direct_edit	t	f	1
-729	2024-09-09 16:45:00.25725+02	direct_edit	t	f	1
-728	2024-09-09 16:44:10.693149+02	direct_edit	t	t	1
-727	2024-09-09 16:43:36.692517+02	direct_edit	t	t	1
-726	2024-09-09 16:43:24.199819+02	direct_edit	t	t	1
-725	2024-09-09 16:43:16.005348+02	direct_edit	t	t	1
-724	2024-09-09 16:43:06.176757+02	direct_edit	t	t	1
-723	2024-09-09 16:42:55.730699+02	direct_edit	t	t	1
-722	2024-09-09 16:42:47.129569+02	direct_edit	t	t	1
-710	2024-09-09 16:37:17.631584+02	direct_edit	t	t	1
-709	2024-09-09 16:33:37.495966+02	direct_edit	t	t	1
-708	2024-09-09 16:32:03.642575+02	direct_edit	t	f	1
-707	2024-09-09 16:31:25.169783+02	direct_edit	t	t	1
-706	2024-09-09 16:31:15.346592+02	direct_edit	t	t	1
-705	2024-09-09 16:23:56.448109+02	direct_edit	t	t	1
-704	2024-09-09 16:23:46.206295+02	direct_edit	t	t	1
-703	2024-09-09 16:23:36.585252+02	direct_edit	t	t	1
-702	2024-09-09 16:22:52.557659+02	direct_edit	t	t	1
-701	2024-09-09 16:22:43.741771+02	direct_edit	t	t	1
-700	2024-09-09 16:22:27.762349+02	direct_edit	t	t	1
-699	2024-09-09 16:21:27.152056+02	direct_edit	t	t	1
-742	2024-09-09 16:46:38.004481+02	management	t	f	\N
-759	2024-09-09 16:53:24.341781+02	management	t	f	\N
-758	2024-09-09 16:52:31.870219+02	direct_edit	t	t	1
-757	2024-09-09 16:51:33.679277+02	direct_edit	t	t	1
-756	2024-09-09 16:51:26.514627+02	direct_edit	t	t	1
-755	2024-09-09 16:51:19.962915+02	direct_edit	t	t	1
-754	2024-09-09 16:51:11.9709+02	direct_edit	t	t	1
-753	2024-09-09 16:51:05.416861+02	direct_edit	t	t	1
-752	2024-09-09 16:50:53.135543+02	direct_edit	t	t	1
-751	2024-09-09 16:50:27.528711+02	direct_edit	t	t	1
-750	2024-09-09 16:50:19.95056+02	direct_edit	t	t	1
-749	2024-09-09 16:50:10.120533+02	direct_edit	t	t	1
-748	2024-09-09 16:49:59.67579+02	direct_edit	t	t	1
-747	2024-09-09 16:49:52.199725+02	direct_edit	t	t	1
-746	2024-09-09 16:49:44.117897+02	direct_edit	t	t	1
-745	2024-09-09 16:49:27.1135+02	direct_edit	t	t	1
-744	2024-09-09 16:49:21.181014+02	direct_edit	t	t	1
-743	2024-09-09 16:49:06.449208+02	direct_edit	t	t	1
-773	2024-09-09 16:57:05.611561+02	management	t	f	\N
-772	2024-09-09 16:56:56.867307+02	direct_edit	t	f	1
-771	2024-09-09 16:56:51.544724+02	direct_edit	t	f	1
-770	2024-09-09 16:56:39.467066+02	direct_edit	t	f	1
-769	2024-09-09 16:56:28.609327+02	direct_edit	t	f	1
-768	2024-09-09 16:56:15.699736+02	direct_edit	t	f	1
-767	2024-09-09 16:56:02.795991+02	direct_edit	t	f	1
-766	2024-09-09 16:55:41.499774+02	direct_edit	t	f	1
-765	2024-09-09 16:55:33.514474+02	direct_edit	t	f	1
-764	2024-09-09 16:55:26.756891+02	direct_edit	t	f	1
-763	2024-09-09 16:55:17.538542+02	direct_edit	t	f	1
-762	2024-09-09 16:55:10.371135+02	direct_edit	t	f	1
-761	2024-09-09 16:54:47.225281+02	direct_edit	t	f	1
-760	2024-09-09 16:54:38.651452+02	direct_edit	t	t	1
-774	2024-09-09 16:57:18.623603+02	management	t	f	\N
-794	2024-09-09 17:03:16.641422+02	management	t	f	\N
-793	2024-09-09 17:03:00.191054+02	direct_edit	t	f	1
-792	2024-09-09 17:02:56.912913+02	direct_edit	t	f	1
-791	2024-09-09 17:02:54.055947+02	direct_edit	t	f	1
-790	2024-09-09 17:02:50.162101+02	direct_edit	t	f	1
-789	2024-09-09 17:02:47.493644+02	direct_edit	t	f	1
-788	2024-09-09 17:02:44.007636+02	direct_edit	t	f	1
-787	2024-09-09 17:02:37.050894+02	direct_edit	t	f	1
-786	2024-09-09 17:02:34.186485+02	direct_edit	t	f	1
-785	2024-09-09 17:02:31.519509+02	direct_edit	t	f	1
-784	2024-09-09 17:02:21.070813+02	direct_edit	t	f	1
-783	2024-09-09 17:02:10.421794+02	direct_edit	t	f	1
-782	2024-09-09 17:01:59.773053+02	direct_edit	t	f	1
-781	2024-09-09 17:01:56.702011+02	direct_edit	t	f	1
-780	2024-09-09 17:01:53.419768+02	direct_edit	t	f	1
-779	2024-09-09 17:01:32.740429+02	direct_edit	t	f	1
-778	2024-09-09 17:01:28.228709+02	direct_edit	t	f	1
-777	2024-09-09 17:01:12.25606+02	direct_edit	t	f	1
-776	2024-09-09 17:01:10.006245+02	direct_edit	t	f	1
-775	2024-09-09 16:59:32.547784+02	direct_edit	t	t	1
-797	2024-09-09 17:06:40.045046+02	management	t	f	\N
-796	2024-09-09 17:06:33.382507+02	direct_edit	t	t	1
-795	2024-09-09 17:06:15.801827+02	direct_edit	t	t	1
-799	2024-09-09 17:10:57.869151+02	management	t	f	\N
-798	2024-09-09 17:10:32.129171+02	direct_edit	t	t	1
-801	2024-09-09 17:13:47.635457+02	management	t	f	\N
-800	2024-09-09 17:13:35.720719+02	direct_edit	t	t	1
-1455	2024-09-17 12:03:27.308168+02	direct_edit	t	f	1
-819	2024-09-09 17:22:02.165001+02	direct_edit	t	t	1
-818	2024-09-09 17:21:37.179556+02	direct_edit	t	t	1
-817	2024-09-09 17:21:27.967841+02	direct_edit	t	t	1
-816	2024-09-09 17:21:20.184142+02	direct_edit	t	t	1
-815	2024-09-09 17:21:05.846867+02	direct_edit	t	t	1
-814	2024-09-09 17:21:00.110493+02	direct_edit	t	t	1
-823	2024-09-09 17:23:38.76088+02	management	t	f	\N
-822	2024-09-09 17:23:21.837302+02	direct_edit	t	t	1
-821	2024-09-09 17:22:39.030878+02	direct_edit	t	t	1
-820	2024-09-09 17:22:21.006923+02	direct_edit	t	t	1
-813	2024-09-09 17:20:32.667788+02	direct_edit	t	t	1
-812	2024-09-09 17:20:07.073381+02	direct_edit	t	t	1
-811	2024-09-09 17:19:58.471777+02	direct_edit	t	t	1
-810	2024-09-09 17:19:37.187125+02	direct_edit	t	t	1
-809	2024-09-09 17:18:31.422418+02	direct_edit	t	t	1
-808	2024-09-09 17:18:18.376823+02	direct_edit	t	t	1
-807	2024-09-09 17:17:56.400423+02	direct_edit	t	t	1
-806	2024-09-09 17:17:35.936931+02	direct_edit	t	t	1
-805	2024-09-09 17:17:15.651589+02	direct_edit	t	t	1
-804	2024-09-09 17:16:59.057677+02	direct_edit	t	t	1
-803	2024-09-09 17:16:48.201833+02	direct_edit	t	t	1
-802	2024-09-09 17:16:27.139051+02	direct_edit	t	t	1
-826	2024-09-09 17:25:05.571358+02	management	t	f	\N
-825	2024-09-09 17:24:31.987392+02	direct_edit	t	t	1
-824	2024-09-09 17:24:24.916009+02	direct_edit	t	t	1
-827	2024-09-09 17:25:18.240423+02	management	t	f	\N
-834	2024-09-09 17:27:00.815678+02	management	t	f	\N
-833	2024-09-09 17:26:42.55383+02	direct_edit	t	f	1
-832	2024-09-09 17:26:37.844086+02	direct_edit	t	f	1
-831	2024-09-09 17:26:32.307001+02	direct_edit	t	f	1
-830	2024-09-09 17:26:28.825505+02	direct_edit	t	f	1
-829	2024-09-09 17:26:13.258574+02	direct_edit	t	f	1
-828	2024-09-09 17:26:11.417793+02	direct_edit	t	f	1
-838	2024-09-09 17:29:18.531931+02	direct_edit	t	t	1
-837	2024-09-09 17:29:07.751553+02	direct_edit	t	t	1
-836	2024-09-09 17:28:47.680282+02	direct_edit	t	t	1
-835	2024-09-09 17:28:31.910177+02	direct_edit	t	t	1
-843	2024-09-09 17:32:04.506854+02	direct_edit	t	f	1
-842	2024-09-09 17:31:23.331322+02	direct_edit	t	t	1
-841	2024-09-09 17:31:14.325872+02	direct_edit	t	t	1
-840	2024-09-09 17:30:39.091431+02	direct_edit	t	t	1
-839	2024-09-09 17:30:23.319439+02	direct_edit	t	t	1
-845	2024-09-09 17:35:32.372085+02	direct_edit	t	t	1
-844	2024-09-09 17:34:35.847373+02	direct_edit	t	t	1
-1456	2024-09-17 12:05:11.639195+02	direct_edit	t	t	1
-901	2024-09-09 17:48:00.104842+02	direct_edit	t	t	1
-900	2024-09-09 17:47:53.961517+02	direct_edit	t	t	1
-899	2024-09-09 17:47:34.720627+02	direct_edit	t	t	1
-898	2024-09-09 17:47:11.567502+02	direct_edit	t	t	1
-897	2024-09-09 17:47:05.015101+02	direct_edit	t	t	1
-896	2024-09-09 17:46:58.051044+02	direct_edit	t	t	1
-895	2024-09-09 17:46:39.419062+02	direct_edit	t	t	1
-894	2024-09-09 17:46:28.153253+02	direct_edit	t	t	1
-893	2024-09-09 17:46:20.782602+02	direct_edit	t	t	1
-892	2024-09-09 17:46:07.205055+02	direct_edit	t	t	1
-891	2024-09-09 17:45:37.158161+02	direct_edit	t	t	1
-890	2024-09-09 17:45:12.783557+02	direct_edit	t	t	1
-889	2024-09-09 17:45:05.613235+02	direct_edit	t	t	1
-888	2024-09-09 17:44:56.398826+02	direct_edit	t	t	1
-887	2024-09-09 17:43:51.895105+02	direct_edit	t	f	1
-886	2024-09-09 17:43:49.0265+02	direct_edit	t	f	1
-885	2024-09-09 17:43:33.252773+02	direct_edit	t	f	1
-884	2024-09-09 17:43:29.770647+02	direct_edit	t	f	1
-883	2024-09-09 17:43:27.5188+02	direct_edit	t	f	1
-882	2024-09-09 17:43:06.423156+02	direct_edit	t	f	1
-881	2024-09-09 17:43:04.578857+02	direct_edit	t	f	1
-880	2024-09-09 17:42:54.749394+02	direct_edit	t	f	1
-879	2024-09-09 17:42:52.906128+02	direct_edit	t	f	1
-878	2024-09-09 17:42:48.809602+02	direct_edit	t	f	1
-877	2024-09-09 17:42:46.352972+02	direct_edit	t	f	1
-876	2024-09-09 17:42:43.081229+02	direct_edit	t	f	1
-875	2024-09-09 17:42:17.68852+02	direct_edit	t	f	1
-874	2024-09-09 17:42:16.054336+02	direct_edit	t	f	1
-873	2024-09-09 17:42:14.412413+02	direct_edit	t	f	1
-872	2024-09-09 17:41:58.843281+02	direct_edit	t	f	1
-871	2024-09-09 17:41:55.769955+02	direct_edit	t	f	1
-870	2024-09-09 17:41:52.284859+02	direct_edit	t	f	1
-869	2024-09-09 17:41:49.008141+02	direct_edit	t	f	1
-868	2024-09-09 17:41:42.457152+02	direct_edit	t	f	1
-867	2024-09-09 17:41:36.513765+02	direct_edit	t	f	1
-866	2024-09-09 17:41:31.392503+02	direct_edit	t	f	1
-865	2024-09-09 17:41:24.428782+02	direct_edit	t	f	1
-864	2024-09-09 17:41:22.794299+02	direct_edit	t	f	1
-863	2024-09-09 17:41:21.567533+02	direct_edit	t	f	1
-862	2024-09-09 17:41:19.929128+02	direct_edit	t	f	1
-861	2024-09-09 17:41:12.144284+02	direct_edit	t	f	1
-860	2024-09-09 17:40:59.239368+02	direct_edit	t	f	1
-859	2024-09-09 17:40:52.685648+02	direct_edit	t	f	1
-858	2024-09-09 17:40:36.100573+02	direct_edit	t	f	1
-857	2024-09-09 17:40:33.646623+02	direct_edit	t	f	1
-856	2024-09-09 17:40:29.750576+02	direct_edit	t	f	1
-855	2024-09-09 17:40:27.905151+02	direct_edit	t	f	1
-854	2024-09-09 17:40:16.844008+02	direct_edit	t	f	1
-853	2024-09-09 17:40:10.088577+02	direct_edit	t	f	1
-852	2024-09-09 17:40:03.742177+02	direct_edit	t	f	1
-851	2024-09-09 17:39:56.779731+02	direct_edit	t	f	1
-850	2024-09-09 17:39:54.729627+02	direct_edit	t	f	1
-849	2024-09-09 17:39:41.825332+02	direct_edit	t	f	1
-848	2024-09-09 17:39:32.931356+02	direct_edit	t	f	1
-847	2024-09-09 17:39:25.442567+02	direct_edit	t	f	1
-846	2024-09-09 17:39:17.075826+02	direct_edit	t	t	1
-926	2024-09-09 17:53:31.791144+02	direct_edit	t	f	1
-925	2024-09-09 17:52:55.852348+02	direct_edit	t	f	1
-924	2024-09-09 17:52:52.779984+02	direct_edit	t	f	1
-923	2024-09-09 17:52:46.220708+02	direct_edit	t	t	1
-922	2024-09-09 17:52:16.741247+02	direct_edit	t	f	1
-921	2024-09-09 17:52:12.633944+02	direct_edit	t	f	1
-920	2024-09-09 17:52:07.108412+02	direct_edit	t	f	1
-919	2024-09-09 17:52:05.060613+02	direct_edit	t	f	1
-918	2024-09-09 17:52:00.146159+02	direct_edit	t	f	1
-917	2024-09-09 17:51:49.905508+02	direct_edit	t	f	1
-916	2024-09-09 17:51:44.786188+02	direct_edit	t	f	1
-915	2024-09-09 17:51:40.070199+02	direct_edit	t	f	1
-914	2024-09-09 17:51:28.805581+02	direct_edit	t	f	1
-913	2024-09-09 17:51:24.094114+02	direct_edit	t	f	1
-912	2024-09-09 17:51:17.336304+02	direct_edit	t	f	1
-911	2024-09-09 17:51:08.537834+02	direct_edit	t	f	1
-910	2024-09-09 17:51:05.051844+02	direct_edit	t	f	1
-909	2024-09-09 17:51:01.335741+02	direct_edit	t	f	1
-908	2024-09-09 17:50:57.679261+02	direct_edit	t	f	1
-907	2024-09-09 17:50:54.607382+02	direct_edit	t	f	1
-906	2024-09-09 17:50:49.494613+02	direct_edit	t	f	1
-905	2024-09-09 17:50:39.659019+02	direct_edit	t	f	1
-904	2024-09-09 17:50:32.484294+02	direct_edit	t	f	1
-903	2024-09-09 17:50:28.593042+02	direct_edit	t	f	1
-902	2024-09-09 17:50:21.840726+02	direct_edit	t	f	1
-931	2024-09-09 17:58:46.883933+02	direct_edit	t	f	1
-930	2024-09-09 17:58:20.877154+02	direct_edit	t	f	1
-929	2024-09-09 17:58:18.622145+02	direct_edit	t	f	1
-928	2024-09-09 17:58:11.04266+02	direct_edit	t	f	1
-927	2024-09-09 17:58:04.89416+02	direct_edit	t	f	1
-956	2024-09-09 18:03:22.546346+02	direct_edit	t	f	1
-955	2024-09-09 18:03:17.836562+02	direct_edit	t	f	1
-954	2024-09-09 18:03:07.595391+02	direct_edit	t	f	1
-953	2024-09-09 18:02:57.559898+02	direct_edit	t	f	1
-952	2024-09-09 18:02:44.461183+02	direct_edit	t	f	1
-951	2024-09-09 18:02:27.666751+02	direct_edit	t	f	1
-950	2024-09-09 18:02:15.780412+02	direct_edit	t	f	1
-949	2024-09-09 18:02:13.938969+02	direct_edit	t	f	1
-948	2024-09-09 18:02:08.614082+02	direct_edit	t	f	1
-947	2024-09-09 18:02:07.178099+02	direct_edit	t	f	1
-946	2024-09-09 18:02:05.745597+02	direct_edit	t	f	1
-945	2024-09-09 18:01:57.141895+02	direct_edit	t	f	1
-944	2024-09-09 18:01:52.024287+02	direct_edit	t	f	1
-943	2024-09-09 18:01:46.493704+02	direct_edit	t	f	1
-942	2024-09-09 18:01:41.373295+02	direct_edit	t	f	1
-941	2024-09-09 18:01:39.426621+02	direct_edit	t	f	1
-940	2024-09-09 18:01:33.183144+02	direct_edit	t	f	1
-939	2024-09-09 18:01:24.378937+02	direct_edit	t	f	1
-938	2024-09-09 18:01:09.226872+02	direct_edit	t	f	1
-937	2024-09-09 18:00:57.75291+02	direct_edit	t	f	1
-936	2024-09-09 18:00:54.680543+02	direct_edit	t	f	1
-935	2024-09-09 18:00:52.226405+02	direct_edit	t	f	1
-934	2024-09-09 18:00:43.004831+02	direct_edit	t	f	1
-933	2024-09-09 18:00:30.306412+02	direct_edit	t	f	1
-932	2024-09-09 18:00:23.136976+02	direct_edit	t	f	1
-959	2024-09-09 18:06:00.660218+02	direct_edit	t	f	1
-958	2024-09-09 18:05:57.593639+02	direct_edit	t	f	1
-957	2024-09-09 18:05:53.901182+02	direct_edit	t	f	1
-961	2024-09-09 18:07:16.455108+02	direct_edit	t	f	1
-960	2024-09-09 18:07:08.651333+02	direct_edit	t	f	1
-963	2024-09-09 18:10:55.58048+02	direct_edit	t	f	1
-962	2024-09-09 18:10:03.135512+02	direct_edit	t	t	1
-969	2024-09-09 18:11:37.356612+02	direct_edit	t	f	1
-968	2024-09-09 18:11:33.467715+02	direct_edit	t	f	1
-967	2024-09-09 18:11:31.418572+02	direct_edit	t	f	1
-966	2024-09-09 18:11:27.736257+02	direct_edit	t	f	1
-965	2024-09-09 18:11:23.83446+02	direct_edit	t	f	1
-964	2024-09-09 18:11:22.399638+02	direct_edit	t	f	1
-977	2024-09-09 18:16:14.656205+02	direct_edit	t	f	1
-976	2024-09-09 18:15:59.502132+02	direct_edit	t	f	1
-975	2024-09-09 18:15:48.938214+02	direct_edit	t	f	1
-974	2024-09-09 18:15:35.119841+02	direct_edit	t	t	1
-973	2024-09-09 18:14:39.017091+02	direct_edit	t	f	1
-972	2024-09-09 18:14:36.152595+02	direct_edit	t	f	1
-971	2024-09-09 18:14:32.053479+02	direct_edit	t	f	1
-970	2024-09-09 18:14:27.543746+02	direct_edit	t	f	1
-1457	2024-09-17 12:05:30.041206+02	direct_edit	t	t	1
-983	2024-09-10 08:22:36.888074+02	direct_edit	t	t	1
-982	2024-09-10 08:22:21.118129+02	direct_edit	t	t	1
-981	2024-09-10 08:22:11.081416+02	direct_edit	t	t	1
-980	2024-09-10 08:21:54.901983+02	direct_edit	t	t	1
-979	2024-09-10 08:21:18.468894+02	direct_edit	t	t	1
-978	2024-09-10 08:18:29.074162+02	direct_edit	t	t	1
-984	2024-09-10 08:33:32.724259+02	management	t	f	\N
-989	2024-09-10 08:37:19.818788+02	direct_edit	t	t	1
-988	2024-09-10 08:36:20.404931+02	direct_edit	t	t	1
-987	2024-09-10 08:35:51.339245+02	direct_edit	t	t	1
-986	2024-09-10 08:34:15.679963+02	direct_edit	t	t	1
-985	2024-09-10 08:34:05.038753+02	direct_edit	t	t	1
-990	2024-09-10 08:38:35.260487+02	management	t	f	\N
-991	2024-09-10 08:42:04.397867+02	management	t	f	\N
-994	2024-09-10 08:52:59.081015+02	management	t	f	\N
-993	2024-09-10 08:52:46.938868+02	direct_edit	t	f	1
-992	2024-09-10 08:50:18.256989+02	direct_edit	t	f	1
-1000	2024-09-10 09:01:49.312009+02	management	t	f	\N
-999	2024-09-10 09:00:45.581379+02	direct_edit	t	t	1
-998	2024-09-10 09:00:11.590715+02	direct_edit	t	t	1
-997	2024-09-10 08:58:58.476081+02	direct_edit	t	t	1
-996	2024-09-10 08:57:30.822485+02	direct_edit	t	t	1
-995	2024-09-10 08:55:38.36628+02	direct_edit	t	t	1
-1001	2024-09-10 09:01:58.836854+02	management	t	f	\N
-1010	2024-09-10 09:08:13.678342+02	direct_edit	t	t	1
-1009	2024-09-10 09:07:58.119787+02	direct_edit	t	t	1
-1008	2024-09-10 09:07:41.11907+02	direct_edit	t	t	1
-1007	2024-09-10 09:07:33.207083+02	direct_edit	t	f	1
-1006	2024-09-10 09:07:25.771546+02	direct_edit	t	t	1
-1005	2024-09-10 09:07:09.579729+02	direct_edit	t	t	1
-1004	2024-09-10 09:07:03.638362+02	direct_edit	t	t	1
-1003	2024-09-10 09:06:36.592162+02	direct_edit	t	f	1
-1002	2024-09-10 09:06:26.145492+02	direct_edit	t	f	1
-1011	2024-09-10 09:08:41.054164+02	management	t	f	\N
-1012	2024-09-10 09:10:25.886125+02	management	t	f	\N
-1013	2024-09-10 09:10:35.84252+02	management	t	f	\N
-1458	2024-09-24 11:20:31.075516+02	management	t	f	\N
-1071	2024-09-10 09:31:44.779065+02	direct_edit	t	f	1
-1070	2024-09-10 09:31:40.68586+02	direct_edit	t	f	1
-1069	2024-09-10 09:31:21.032366+02	direct_edit	t	f	1
-1068	2024-09-10 09:31:17.138664+02	direct_edit	t	f	1
-1067	2024-09-10 09:31:04.22757+02	direct_edit	t	t	1
-1066	2024-09-10 09:30:56.237034+02	direct_edit	t	f	1
-1065	2024-09-10 09:30:34.124262+02	direct_edit	t	f	1
-1064	2024-09-10 09:30:26.953416+02	direct_edit	t	f	1
-1063	2024-09-10 09:30:17.121261+02	direct_edit	t	f	1
-1062	2024-09-10 09:30:09.746568+02	direct_edit	t	f	1
-1061	2024-09-10 09:29:57.663086+02	direct_edit	t	f	1
-1060	2024-09-10 09:29:55.818907+02	direct_edit	t	f	1
-1059	2024-09-10 09:29:40.664954+02	direct_edit	t	f	1
-1058	2024-09-10 09:29:38.412682+02	direct_edit	t	f	1
-1057	2024-09-10 09:29:30.424139+02	direct_edit	t	f	1
-1056	2024-09-10 09:29:23.46604+02	direct_edit	t	f	1
-1055	2024-09-10 09:28:58.68489+02	direct_edit	t	f	1
-1054	2024-09-10 09:28:15.47345+02	direct_edit	t	f	1
-1053	2024-09-10 09:27:50.489936+02	direct_edit	t	f	1
-1052	2024-09-10 09:27:36.763103+02	direct_edit	t	f	1
-1051	2024-09-10 09:27:08.700572+02	direct_edit	t	f	1
-1050	2024-09-10 09:27:03.17155+02	direct_edit	t	f	1
-1049	2024-09-10 09:26:41.671668+02	direct_edit	t	f	1
-1048	2024-09-10 09:26:24.094783+02	direct_edit	t	f	1
-1047	2024-09-10 09:26:05.018583+02	direct_edit	t	f	1
-1046	2024-09-10 09:25:50.466543+02	direct_edit	t	f	1
-1045	2024-09-10 09:25:17.916165+02	direct_edit	t	f	1
-1081	2024-09-10 09:33:44.595645+02	direct_edit	t	f	1
-1080	2024-09-10 09:33:33.531432+02	direct_edit	t	f	1
-1079	2024-09-10 09:33:20.831094+02	direct_edit	t	f	1
-1078	2024-09-10 09:33:17.144203+02	direct_edit	t	f	1
-1077	2024-09-10 09:33:05.270051+02	direct_edit	t	f	1
-1076	2024-09-10 09:32:55.03399+02	direct_edit	t	f	1
-1075	2024-09-10 09:32:44.785066+02	direct_edit	t	f	1
-1074	2024-09-10 09:32:33.119238+02	direct_edit	t	f	1
-1073	2024-09-10 09:32:26.361774+02	direct_edit	t	f	1
-1072	2024-09-10 09:32:22.469286+02	direct_edit	t	f	1
-1044	2024-09-10 09:25:11.968955+02	direct_edit	t	f	1
-1043	2024-09-10 09:25:09.919392+02	direct_edit	t	f	1
-1042	2024-09-10 09:24:52.717905+02	direct_edit	t	f	1
-1041	2024-09-10 09:24:49.435088+02	direct_edit	t	f	1
-1040	2024-09-10 09:24:46.773264+02	direct_edit	t	f	1
-1039	2024-09-10 09:24:23.845091+02	direct_edit	t	f	1
-1038	2024-09-10 09:24:20.560327+02	direct_edit	t	f	1
-1037	2024-09-10 09:24:18.92284+02	direct_edit	t	f	1
-1036	2024-09-10 09:23:50.864879+02	direct_edit	t	f	1
-1035	2024-09-10 09:23:44.112658+02	direct_edit	t	f	1
-1034	2024-09-10 09:23:41.857947+02	direct_edit	t	f	1
-1033	2024-09-10 09:23:39.189714+02	direct_edit	t	f	1
-1032	2024-09-10 09:23:36.319899+02	direct_edit	t	f	1
-1031	2024-09-10 09:23:10.721979+02	direct_edit	t	t	1
-1030	2024-09-10 09:23:01.086375+02	direct_edit	t	t	1
-1029	2024-09-10 09:22:03.150649+02	direct_edit	t	t	1
-1028	2024-09-10 09:21:40.824725+02	direct_edit	t	t	1
-1027	2024-09-10 09:20:56.365353+02	direct_edit	t	t	1
-1026	2024-09-10 09:20:42.296313+02	direct_edit	t	t	1
-1025	2024-09-10 09:19:49.695157+02	direct_edit	t	t	1
-1024	2024-09-10 09:19:25.260586+02	direct_edit	t	t	1
-1023	2024-09-10 09:19:13.366464+02	direct_edit	t	t	1
-1022	2024-09-10 09:17:59.858424+02	direct_edit	t	t	1
-1021	2024-09-10 09:17:22.980022+02	direct_edit	t	t	1
-1020	2024-09-10 09:16:23.387289+02	direct_edit	t	t	1
-1019	2024-09-10 09:15:02.46272+02	direct_edit	t	t	1
-1018	2024-09-10 09:14:53.455803+02	direct_edit	t	t	1
-1017	2024-09-10 09:14:30.148124+02	direct_edit	t	t	1
-1016	2024-09-10 09:13:29.931682+02	direct_edit	t	t	1
-1015	2024-09-10 09:11:40.329937+02	direct_edit	t	f	1
-1014	2024-09-10 09:11:33.776659+02	direct_edit	t	f	1
-1082	2024-09-10 09:34:15.759685+02	management	t	f	\N
-1105	2024-09-10 09:38:24.963291+02	direct_edit	t	f	1
-1104	2024-09-10 09:38:21.27844+02	direct_edit	t	f	1
-1103	2024-09-10 09:38:18.818351+02	direct_edit	t	f	1
-1102	2024-09-10 09:38:16.157492+02	direct_edit	t	f	1
-1101	2024-09-10 09:38:12.263816+02	direct_edit	t	f	1
-1100	2024-09-10 09:38:07.560253+02	direct_edit	t	f	1
-1099	2024-09-10 09:38:01.619635+02	direct_edit	t	f	1
-1098	2024-09-10 09:37:57.925508+02	direct_edit	t	f	1
-1097	2024-09-10 09:37:55.678166+02	direct_edit	t	f	1
-1096	2024-09-10 09:37:50.968628+02	direct_edit	t	f	1
-1095	2024-09-10 09:37:46.444113+02	direct_edit	t	f	1
-1094	2024-09-10 09:37:34.173938+02	direct_edit	t	f	1
-1093	2024-09-10 09:37:26.796477+02	direct_edit	t	f	1
-1092	2024-09-10 09:37:18.814936+02	direct_edit	t	f	1
-1091	2024-09-10 09:37:11.847109+02	direct_edit	t	f	1
-1090	2024-09-10 09:36:38.88559+02	direct_edit	t	f	1
-1089	2024-09-10 09:36:35.349165+02	direct_edit	t	f	1
-1088	2024-09-10 09:36:28.637432+02	direct_edit	t	f	1
-1087	2024-09-10 09:36:23.315367+02	direct_edit	t	f	1
-1086	2024-09-10 09:36:18.198093+02	direct_edit	t	f	1
-1085	2024-09-10 09:36:13.895611+02	direct_edit	t	f	1
-1084	2024-09-10 09:36:10.619955+02	direct_edit	t	f	1
-1083	2024-09-10 09:35:59.966899+02	direct_edit	t	f	1
-1106	2024-09-10 09:38:44.865336+02	management	t	f	\N
-1117	2024-09-10 09:40:17.832002+02	management	t	f	\N
-1116	2024-09-10 09:40:02.665381+02	direct_edit	t	f	1
-1115	2024-09-10 09:39:59.798852+02	direct_edit	t	f	1
-1114	2024-09-10 09:39:55.900552+02	direct_edit	t	f	1
-1113	2024-09-10 09:39:53.240895+02	direct_edit	t	f	1
-1112	2024-09-10 09:39:50.790082+02	direct_edit	t	f	1
-1111	2024-09-10 09:39:48.326713+02	direct_edit	t	f	1
-1110	2024-09-10 09:39:41.155381+02	direct_edit	t	f	1
-1109	2024-09-10 09:39:38.287972+02	direct_edit	t	f	1
-1108	2024-09-10 09:39:34.601079+02	direct_edit	t	f	1
-1107	2024-09-10 09:39:27.643685+02	direct_edit	t	f	1
-1122	2024-09-10 09:43:09.431356+02	direct_edit	t	t	1
-1121	2024-09-10 09:43:02.673132+02	direct_edit	t	f	1
-1120	2024-09-10 09:42:58.371451+02	direct_edit	t	f	1
-1119	2024-09-10 09:42:47.312706+02	direct_edit	t	f	1
-1118	2024-09-10 09:42:37.892976+02	direct_edit	t	t	1
-1123	2024-09-10 09:43:47.367298+02	management	t	f	\N
-1125	2024-09-10 10:51:41.065157+02	direct_edit	t	t	1
-1124	2024-09-10 10:51:26.319809+02	direct_edit	t	t	1
-1126	2024-09-10 10:52:45.444994+02	management	t	f	\N
-1139	2024-09-10 11:03:25.386854+02	direct_edit	t	f	1
-1138	2024-09-10 11:03:20.265732+02	direct_edit	t	f	1
-1137	2024-09-10 11:03:11.255069+02	direct_edit	t	f	1
-1136	2024-09-10 11:03:02.247125+02	direct_edit	t	f	1
-1135	2024-09-10 11:02:55.688952+02	direct_edit	t	f	1
-1134	2024-09-10 11:02:39.093267+02	direct_edit	t	t	1
-1133	2024-09-10 11:02:21.072475+02	direct_edit	t	t	1
-1132	2024-09-10 11:02:07.355806+02	direct_edit	t	t	1
-1131	2024-09-10 11:01:51.406459+02	direct_edit	t	t	1
-1130	2024-09-10 10:59:34.999033+02	direct_edit	t	t	1
-1129	2024-09-10 10:59:04.697292+02	direct_edit	t	t	1
-1128	2024-09-10 10:58:29.055523+02	direct_edit	t	t	1
-1127	2024-09-10 10:55:16.552757+02	direct_edit	t	t	1
-1459	2024-09-24 11:23:49.369172+02	management	t	f	\N
-1168	2024-09-10 11:16:52.598778+02	management	t	f	\N
-1167	2024-09-10 11:16:31.015353+02	direct_edit	t	t	1
-1166	2024-09-10 11:16:19.541274+02	direct_edit	t	t	1
-1165	2024-09-10 11:15:54.964396+02	direct_edit	t	t	1
-1164	2024-09-10 11:15:42.471133+02	direct_edit	t	t	1
-1163	2024-09-10 11:15:25.883527+02	direct_edit	t	t	1
-1162	2024-09-10 11:15:13.185646+02	direct_edit	t	t	1
-1161	2024-09-10 11:14:41.031198+02	direct_edit	t	t	1
-1160	2024-09-10 11:14:27.927123+02	direct_edit	t	t	1
-1159	2024-09-10 11:14:06.008888+02	direct_edit	t	t	1
-1158	2024-09-10 11:13:51.468061+02	direct_edit	t	t	1
-1157	2024-09-10 11:10:20.722623+02	direct_edit	t	t	1
-1156	2024-09-10 11:09:55.737451+02	direct_edit	t	t	1
-1155	2024-09-10 11:09:07.642834+02	direct_edit	t	t	1
-1154	2024-09-10 11:04:49.776333+02	direct_edit	t	f	1
-1153	2024-09-10 11:04:46.905732+02	direct_edit	t	t	1
-1152	2024-09-10 11:04:38.296838+02	direct_edit	t	f	1
-1151	2024-09-10 11:04:37.078347+02	direct_edit	t	f	1
-1150	2024-09-10 11:04:34.820855+02	direct_edit	t	f	1
-1149	2024-09-10 11:04:32.169107+02	direct_edit	t	f	1
-1148	2024-09-10 11:04:29.093588+02	direct_edit	t	f	1
-1147	2024-09-10 11:04:25.603541+02	direct_edit	t	f	1
-1146	2024-09-10 11:04:05.750208+02	direct_edit	t	f	1
-1145	2024-09-10 11:04:01.84966+02	direct_edit	t	f	1
-1144	2024-09-10 11:04:00.209123+02	direct_edit	t	f	1
-1143	2024-09-10 11:03:57.958611+02	direct_edit	t	f	1
-1142	2024-09-10 11:03:55.90805+02	direct_edit	t	f	1
-1141	2024-09-10 11:03:53.508422+02	direct_edit	t	f	1
-1140	2024-09-10 11:03:48.938429+02	direct_edit	t	f	1
-1170	2024-09-10 11:20:52.348011+02	direct_edit	t	t	1
-1169	2024-09-10 11:20:32.712751+02	direct_edit	t	t	1
-1178	2024-09-10 12:35:46.134569+02	direct_edit	t	t	1
-1177	2024-09-10 12:35:24.631662+02	direct_edit	t	t	1
-1176	2024-09-10 12:34:37.526944+02	direct_edit	t	t	1
-1175	2024-09-10 12:34:22.781024+02	direct_edit	t	t	1
-1174	2024-09-10 12:33:50.428653+02	direct_edit	t	t	1
-1173	2024-09-10 12:33:17.025546+02	direct_edit	t	f	1
-1172	2024-09-10 12:33:05.354592+02	direct_edit	t	f	1
-1171	2024-09-10 12:28:43.017777+02	direct_edit	t	t	1
-1179	2024-09-10 12:36:17.624541+02	management	t	f	\N
-1195	2024-09-10 12:40:53.357321+02	direct_edit	t	f	1
-1194	2024-09-10 12:40:49.054053+02	direct_edit	t	f	1
-1193	2024-09-10 12:40:38.8102+02	direct_edit	t	f	1
-1192	2024-09-10 12:40:10.744638+02	direct_edit	t	t	1
-1191	2024-09-10 12:39:48.215218+02	direct_edit	t	t	1
-1190	2024-09-10 12:39:28.122349+02	direct_edit	t	t	1
-1189	2024-09-10 12:39:07.049401+02	direct_edit	t	t	1
-1188	2024-09-10 12:38:41.448708+02	direct_edit	t	t	1
-1187	2024-09-10 12:38:16.062679+02	direct_edit	t	f	1
-1186	2024-09-10 12:38:10.140262+02	direct_edit	t	f	1
-1185	2024-09-10 12:37:59.461945+02	direct_edit	t	t	1
-1184	2024-09-10 12:37:52.088878+02	direct_edit	t	t	1
-1183	2024-09-10 12:37:45.124498+02	direct_edit	t	t	1
-1182	2024-09-10 12:37:36.939331+02	direct_edit	t	t	1
-1181	2024-09-10 12:37:18.913463+02	direct_edit	t	t	1
-1180	2024-09-10 12:37:11.339574+02	direct_edit	t	t	1
-1196	2024-09-10 12:41:26.170354+02	management	t	f	\N
-1197	2024-09-10 12:42:34.309452+02	direct_edit	t	t	1
-1198	2024-09-10 12:42:55.667308+02	management	t	f	\N
-1202	2024-09-10 12:44:00.73906+02	direct_edit	t	f	1
-1201	2024-09-10 12:43:57.465429+02	direct_edit	t	f	1
-1200	2024-09-10 12:43:45.791858+02	direct_edit	t	f	1
-1199	2024-09-10 12:43:43.534028+02	direct_edit	t	f	1
-1203	2024-09-10 12:44:14.757652+02	management	t	f	\N
-1205	2024-09-10 12:48:32.635643+02	management	t	f	\N
-1204	2024-09-10 12:47:35.778796+02	direct_edit	t	t	1
-1206	2024-09-10 12:48:44.226134+02	management	t	f	\N
-1213	2024-09-10 13:02:21.142448+02	direct_edit	t	t	1
-1212	2024-09-10 13:01:57.63076+02	direct_edit	t	t	1
-1211	2024-09-10 13:01:34.242533+02	direct_edit	t	t	1
-1210	2024-09-10 13:01:22.7795+02	direct_edit	t	t	1
-1209	2024-09-10 13:00:59.456046+02	direct_edit	t	t	1
-1208	2024-09-10 12:59:52.863624+02	direct_edit	t	t	1
-1207	2024-09-10 12:59:46.925942+02	direct_edit	t	t	1
-1214	2024-09-10 13:02:52.771715+02	management	t	f	\N
-1227	2024-09-10 14:18:13.775765+02	management	t	f	\N
-1226	2024-09-10 14:17:55.290982+02	direct_edit	t	t	1
-1225	2024-09-10 14:17:39.309157+02	direct_edit	t	t	1
-1224	2024-09-10 14:17:24.571456+02	direct_edit	t	t	1
-1223	2024-09-10 14:17:06.341263+02	direct_edit	t	t	1
-1222	2024-09-10 14:16:50.569837+02	direct_edit	t	t	1
-1221	2024-09-10 14:16:29.065862+02	direct_edit	t	t	1
-1220	2024-09-10 14:15:31.1649+02	direct_edit	t	t	1
-1219	2024-09-10 13:06:44.931091+02	direct_edit	t	t	1
-1218	2024-09-10 13:03:47.981823+02	direct_edit	t	t	1
-1217	2024-09-10 13:03:41.634863+02	direct_edit	t	f	1
-1216	2024-09-10 13:03:37.94683+02	direct_edit	t	f	1
-1215	2024-09-10 13:03:33.239261+02	direct_edit	t	t	1
-1228	2024-09-10 14:18:25.071164+02	management	t	f	\N
-1230	2024-09-10 14:20:36.671186+02	direct_edit	t	t	1
-1229	2024-09-10 14:19:55.335175+02	direct_edit	t	t	1
-1231	2024-09-10 14:21:40.212905+02	management	t	f	\N
-1239	2024-09-10 14:27:50.260162+02	direct_edit	t	t	1
-1238	2024-09-10 14:26:50.892246+02	direct_edit	t	t	1
-1237	2024-09-10 14:26:34.900505+02	direct_edit	t	t	1
-1236	2024-09-10 14:25:49.60828+02	direct_edit	t	f	1
-1235	2024-09-10 14:25:27.295137+02	direct_edit	t	f	1
-1234	2024-09-10 14:25:19.913659+02	direct_edit	t	f	1
-1233	2024-09-10 14:23:27.074047+02	direct_edit	t	t	1
-1232	2024-09-10 14:23:17.85972+02	direct_edit	t	t	1
-1245	2024-09-10 14:34:43.976903+02	direct_edit	t	t	1
-1244	2024-09-10 14:34:32.929968+02	direct_edit	t	t	1
-1243	2024-09-10 14:34:08.621853+02	direct_edit	t	f	1
-1242	2024-09-10 14:29:53.129579+02	direct_edit	t	f	1
-1241	2024-09-10 14:29:48.418817+02	direct_edit	t	f	1
-1240	2024-09-10 14:29:44.331845+02	direct_edit	t	f	1
-1246	2024-09-10 14:35:07.360218+02	management	t	f	\N
-1460	2024-09-24 11:26:09.867117+02	management	t	f	\N
-1255	2024-09-10 15:41:45.300033+02	direct_edit	t	f	1
-1254	2024-09-10 15:41:22.35702+02	direct_edit	t	f	1
-1253	2024-09-10 15:40:51.841158+02	direct_edit	t	f	1
-1252	2024-09-10 15:40:00.841204+02	direct_edit	t	f	1
-1251	2024-09-10 15:29:49.496297+02	direct_edit	t	t	1
-1250	2024-09-10 15:28:45.780241+02	direct_edit	t	t	1
-1249	2024-09-10 15:24:39.433561+02	direct_edit	t	t	1
-1248	2024-09-10 15:20:33.032079+02	direct_edit	t	f	1
-1247	2024-09-10 15:20:22.790597+02	direct_edit	t	f	1
-1256	2024-09-10 15:42:48.157359+02	management	t	f	\N
-1261	2024-09-11 14:29:25.106061+02	direct_edit	t	t	1
-1260	2024-09-11 14:28:51.30691+02	direct_edit	t	t	1
-1259	2024-09-11 14:25:40.227963+02	direct_edit	t	t	1
-1258	2024-09-11 14:25:09.922248+02	direct_edit	t	t	1
-1257	2024-09-11 14:21:56.725799+02	direct_edit	t	t	1
-1262	2024-09-11 15:04:14.763689+02	management	t	f	\N
-1270	2024-09-12 16:52:38.483398+02	direct_edit	t	t	1
-1269	2024-09-12 16:52:26.395897+02	direct_edit	t	f	1
-1268	2024-09-12 16:52:19.234856+02	direct_edit	t	t	1
-1267	2024-09-12 16:52:04.690547+02	direct_edit	t	t	1
-1266	2024-09-12 16:51:54.044696+02	direct_edit	t	t	1
-1265	2024-09-12 16:51:44.21068+02	direct_edit	t	t	1
-1264	2024-09-12 16:51:31.52176+02	direct_edit	t	t	1
-1263	2024-09-12 16:51:19.841867+02	direct_edit	t	t	1
-1271	2024-09-12 16:54:00.590495+02	direct_edit	t	f	1
-1272	2024-09-12 16:55:41.985865+02	direct_edit	t	t	1
-1273	2024-09-12 17:19:36.778805+02	direct_edit	t	t	1
-1276	2024-09-12 17:46:36.388235+02	direct_edit	t	t	1
-1275	2024-09-12 17:46:26.558709+02	direct_edit	t	t	1
-1274	2024-09-12 17:31:08.423966+02	direct_edit	t	t	1
-1277	2024-09-12 17:48:42.772787+02	direct_edit	t	t	1
-1278	2024-09-12 17:50:12.045228+02	direct_edit	t	t	1
-1279	2024-09-12 17:52:41.961572+02	direct_edit	t	t	1
-1284	2024-09-12 17:54:51.198154+02	direct_edit	t	t	1
-1283	2024-09-12 17:54:36.655943+02	direct_edit	t	t	1
-1282	2024-09-12 17:54:20.069994+02	direct_edit	t	t	1
-1281	2024-09-12 17:54:02.455219+02	direct_edit	t	t	1
-1280	2024-09-12 17:53:50.166135+02	direct_edit	t	t	1
-1286	2024-09-12 17:55:47.513854+02	direct_edit	t	t	1
-1285	2024-09-12 17:55:39.116675+02	direct_edit	t	t	1
-1287	2024-09-12 17:56:49.572548+02	direct_edit	t	t	1
-1288	2024-09-12 17:57:09.83227+02	management	t	f	\N
-1290	2024-09-12 17:58:29.768858+02	management	t	f	\N
-1289	2024-09-12 17:58:22.553631+02	direct_edit	t	t	1
-1291	2024-09-12 18:40:57.370124+02	management	t	f	\N
-1299	2024-09-13 11:46:57.590404+02	management	t	f	\N
-1298	2024-09-13 11:46:38.273145+02	direct_edit	t	t	1
-1297	2024-09-13 11:46:06.120767+02	direct_edit	t	t	1
-1296	2024-09-13 11:45:57.694057+02	direct_edit	t	t	1
-1295	2024-09-13 11:45:26.595928+02	direct_edit	t	t	1
-1294	2024-09-13 11:43:33.110826+02	direct_edit	t	t	1
-1293	2024-09-13 11:43:25.525499+02	direct_edit	t	t	1
-1292	2024-09-13 11:42:31.456966+02	direct_edit	t	t	1
-1301	2024-09-13 11:47:58.598763+02	management	t	f	\N
-1300	2024-09-13 11:47:42.791393+02	direct_edit	t	t	1
-1311	2024-09-13 11:52:32.79547+02	management	t	f	\N
-1310	2024-09-13 11:52:17.616863+02	direct_edit	t	f	1
-1309	2024-09-13 11:52:01.63862+02	direct_edit	t	f	1
-1308	2024-09-13 11:51:23.334695+02	direct_edit	t	t	1
-1307	2024-09-13 11:51:18.214351+02	direct_edit	t	t	1
-1306	2024-09-13 11:51:05.518083+02	direct_edit	t	t	1
-1305	2024-09-13 11:50:47.07476+02	direct_edit	t	t	1
-1304	2024-09-13 11:50:26.220617+02	direct_edit	t	t	1
-1303	2024-09-13 11:49:27.857506+02	direct_edit	t	t	1
-1302	2024-09-13 11:48:40.749106+02	direct_edit	t	t	1
-1318	2024-09-13 11:54:08.479852+02	management	t	f	\N
-1317	2024-09-13 11:53:57.350878+02	direct_edit	t	f	1
-1316	2024-09-13 11:53:51.823046+02	direct_edit	t	f	1
-1315	2024-09-13 11:53:46.086056+02	direct_edit	t	f	1
-1314	2024-09-13 11:53:39.330484+02	direct_edit	t	f	1
-1313	2024-09-13 11:53:30.926138+02	direct_edit	t	f	1
-1312	2024-09-13 11:53:21.71681+02	direct_edit	t	t	1
-1323	2024-09-13 11:57:07.100504+02	management	t	f	\N
-1322	2024-09-13 11:56:07.436373+02	direct_edit	t	t	1
-1321	2024-09-13 11:55:53.469571+02	direct_edit	t	t	1
-1320	2024-09-13 11:55:06.363944+02	direct_edit	t	t	1
-1319	2024-09-13 11:54:53.695535+02	direct_edit	t	t	1
-1324	2024-09-13 11:57:18.7182+02	management	t	f	\N
-1330	2024-09-13 12:00:20.828182+02	management	t	f	\N
-1329	2024-09-13 12:00:13.154724+02	direct_edit	t	t	1
-1328	2024-09-13 11:59:49.840141+02	direct_edit	t	t	1
-1327	2024-09-13 11:59:28.954764+02	direct_edit	t	t	1
-1326	2024-09-13 11:59:08.876721+02	direct_edit	t	t	1
-1325	2024-09-13 11:58:31.812257+02	direct_edit	t	t	1
-1331	2024-09-13 12:00:32.546703+02	management	t	f	\N
-1334	2024-09-13 12:02:33.270975+02	management	t	f	\N
-1333	2024-09-13 12:02:25.260072+02	direct_edit	t	t	1
-1332	2024-09-13 12:02:16.071062+02	direct_edit	t	t	1
-1336	2024-09-13 12:03:21.208059+02	management	t	f	\N
-1335	2024-09-13 12:03:13.626379+02	direct_edit	t	t	1
-1338	2024-09-13 12:04:16.748769+02	management	t	f	\N
-1337	2024-09-13 12:04:06.26271+02	direct_edit	t	t	1
-1341	2024-09-13 12:06:17.274559+02	management	t	f	\N
-1340	2024-09-13 12:06:07.8786+02	direct_edit	t	t	1
-1339	2024-09-13 12:05:00.939688+02	direct_edit	t	t	1
-1343	2024-09-13 12:07:04.478183+02	management	t	f	\N
-1342	2024-09-13 12:06:57.468532+02	direct_edit	t	t	1
-1345	2024-09-13 12:07:52.984192+02	management	t	f	\N
-1344	2024-09-13 12:07:46.011761+02	direct_edit	t	t	1
-1348	2024-09-13 12:08:46.48357+02	management	t	f	\N
-1347	2024-09-13 12:08:39.020339+02	direct_edit	t	t	1
-1346	2024-09-13 12:08:29.631386+02	direct_edit	t	t	1
-1350	2024-09-13 12:10:18.42692+02	management	t	f	\N
-1349	2024-09-13 12:10:10.975279+02	direct_edit	t	t	1
-1352	2024-09-13 12:12:15.610325+02	management	t	f	\N
-1351	2024-09-13 12:10:47.841157+02	direct_edit	t	t	1
-1354	2024-09-13 12:13:05.013524+02	management	t	f	\N
-1353	2024-09-13 12:12:59.121993+02	direct_edit	t	t	1
-1358	2024-09-13 12:14:25.413255+02	management	t	f	\N
-1357	2024-09-13 12:14:16.945085+02	direct_edit	t	t	1
-1356	2024-09-13 12:14:11.622835+02	direct_edit	t	t	1
-1355	2024-09-13 12:14:07.297797+02	direct_edit	t	t	1
-1360	2024-09-13 12:15:03.879754+02	management	t	f	\N
-1359	2024-09-13 12:14:56.473102+02	direct_edit	t	t	1
-1362	2024-09-13 12:15:47.602122+02	management	t	f	\N
-1461	2024-09-24 11:26:50.419953+02	management	t	t	\N
-1361	2024-09-13 12:15:41.122242+02	direct_edit	t	t	1
-1364	2024-09-13 12:16:33.767728+02	management	t	f	\N
-1363	2024-09-13 12:16:26.790795+02	direct_edit	t	t	1
-1366	2024-09-13 12:17:17.002324+02	management	t	f	\N
-1365	2024-09-13 12:17:09.184966+02	direct_edit	t	t	1
-1368	2024-09-13 12:17:54.917009+02	management	t	f	\N
-1367	2024-09-13 12:17:45.654775+02	direct_edit	t	t	1
-1376	2024-09-14 09:38:23.226492+02	management	t	f	\N
-1375	2024-09-14 09:37:54.918275+02	direct_edit	t	t	1
-1374	2024-09-14 09:31:41.807829+02	direct_edit	t	t	1
-1373	2024-09-14 09:31:29.894066+02	direct_edit	t	t	1
-1372	2024-09-14 09:31:20.49625+02	direct_edit	t	t	1
-1371	2024-09-14 09:31:06.981565+02	direct_edit	t	t	1
-1370	2024-09-14 09:30:50.598423+02	direct_edit	t	t	1
-1369	2024-09-14 09:30:23.565052+02	direct_edit	t	t	1
-1378	2024-09-14 09:41:40.772276+02	management	t	f	\N
-1377	2024-09-14 09:41:33.68215+02	direct_edit	t	t	1
-1380	2024-09-14 09:44:31.52611+02	management	t	f	\N
-1379	2024-09-14 09:44:24.084008+02	direct_edit	t	t	1
-1381	2024-09-14 09:44:42.796719+02	management	t	f	\N
-1382	2024-09-14 10:07:07.642383+02	management	t	f	\N
-1383	2024-09-14 10:08:06.892598+02	management	t	f	\N
-1392	2024-09-17 09:27:25.135224+02	direct_edit	t	f	1
-1391	2024-09-17 09:21:04.067146+02	direct_edit	t	f	1
-1390	2024-09-17 09:18:17.567738+02	direct_edit	t	f	1
-1389	2024-09-17 09:17:02.403835+02	direct_edit	t	f	1
-1388	2024-09-17 09:13:24.078989+02	direct_edit	t	f	1
-1387	2024-09-17 09:05:02.1913+02	direct_edit	t	f	1
-1386	2024-09-16 13:42:47.35352+02	direct_edit	t	f	1
-1385	2024-09-16 13:40:31.779548+02	direct_edit	t	f	1
-1384	2024-09-16 13:40:10.877233+02	direct_edit	t	f	1
-1393	2024-09-17 09:28:20.104683+02	direct_edit	t	f	1
-1397	2024-09-17 09:51:20.07211+02	direct_edit	t	f	1
-1396	2024-09-17 09:46:27.647246+02	direct_edit	t	t	1
-1395	2024-09-17 09:44:43.784645+02	direct_edit	t	t	1
-1394	2024-09-17 09:29:26.460936+02	direct_edit	t	f	1
-1409	2024-09-17 10:08:34.297084+02	direct_edit	t	t	1
-1408	2024-09-17 10:08:28.562649+02	direct_edit	t	t	1
-1407	2024-09-17 10:08:16.012427+02	direct_edit	t	t	1
-1406	2024-09-17 10:08:10.332891+02	direct_edit	t	t	1
-1405	2024-09-17 10:08:04.802643+02	direct_edit	t	t	1
-1404	2024-09-17 10:07:54.562573+02	direct_edit	t	t	1
-1403	2024-09-17 10:03:38.970107+02	direct_edit	t	t	1
-1402	2024-09-17 10:00:28.296372+02	direct_edit	t	t	1
-1401	2024-09-17 10:00:19.082067+02	direct_edit	t	t	1
-1400	2024-09-17 10:00:07.843568+02	direct_edit	t	t	1
-1399	2024-09-17 09:57:44.266739+02	direct_edit	t	t	1
-1398	2024-09-17 09:53:26.858845+02	direct_edit	t	f	1
-1412	2024-09-17 10:10:25.17003+02	direct_edit	t	t	1
-1411	2024-09-17 10:09:50.072073+02	direct_edit	t	t	1
-1410	2024-09-17 10:09:42.90533+02	direct_edit	t	t	1
-1416	2024-09-17 10:12:17.736897+02	direct_edit	t	t	1
-1415	2024-09-17 10:12:05.857031+02	direct_edit	t	t	1
-1414	2024-09-17 10:12:00.121251+02	direct_edit	t	t	1
-1413	2024-09-17 10:11:11.788843+02	direct_edit	t	t	1
-1417	2024-09-17 10:13:06.272245+02	direct_edit	t	t	1
-1418	2024-09-17 10:13:59.321358+02	direct_edit	t	t	1
-1421	2024-09-17 10:15:17.756792+02	direct_edit	t	t	1
-1420	2024-09-17 10:14:59.12088+02	direct_edit	t	t	1
-1419	2024-09-17 10:14:52.163509+02	direct_edit	t	t	1
-1423	2024-09-17 10:18:21.474712+02	direct_edit	t	t	1
-1422	2024-09-17 10:18:13.689605+02	direct_edit	t	t	1
-1424	2024-09-17 10:20:15.545646+02	direct_edit	t	t	1
-1447	2024-09-17 11:51:43.294892+02	direct_edit	t	t	1
-1446	2024-09-17 11:51:29.159128+02	direct_edit	t	f	1
-1445	2024-09-17 11:51:02.081944+02	direct_edit	t	f	1
-1444	2024-09-17 11:50:26.890106+02	direct_edit	t	t	1
-1443	2024-09-17 11:48:18.483833+02	direct_edit	t	t	1
-1442	2024-09-17 11:46:10.929869+02	direct_edit	t	t	1
-1441	2024-09-17 11:46:03.479578+02	direct_edit	t	t	1
-1440	2024-09-17 11:45:59.588099+02	direct_edit	t	t	1
-1439	2024-09-17 11:45:52.827538+02	direct_edit	t	t	1
-1438	2024-09-17 11:45:46.485474+02	direct_edit	t	t	1
-1437	2024-09-17 11:45:43.407182+02	direct_edit	t	t	1
-1436	2024-09-17 11:45:40.336744+02	direct_edit	t	t	1
-1435	2024-09-17 11:45:33.167597+02	direct_edit	t	t	1
-1434	2024-09-17 11:45:28.660578+02	direct_edit	t	t	1
-1433	2024-09-17 11:45:22.10772+02	direct_edit	t	t	1
-1432	2024-09-17 11:32:36.370708+02	direct_edit	t	f	1
-1431	2024-09-17 11:31:05.023255+02	direct_edit	t	f	1
-1430	2024-09-17 11:30:57.037458+02	direct_edit	t	f	1
-1429	2024-09-17 11:21:36.275858+02	direct_edit	t	f	1
-1428	2024-09-17 11:21:14.154067+02	direct_edit	t	f	1
-1427	2024-09-17 11:17:57.13612+02	direct_edit	t	t	1
-1426	2024-09-17 11:17:50.579633+02	direct_edit	t	f	1
-1425	2024-09-17 11:11:18.984082+02	direct_edit	t	f	1
-1450	2024-09-17 11:57:49.847976+02	direct_edit	t	t	1
-1449	2024-09-17 11:55:01.292517+02	direct_edit	t	t	1
-1448	2024-09-17 11:54:20.130126+02	direct_edit	t	t	1
-1462	2024-09-24 12:04:08.949053+02	management	t	t	\N
-1464	2024-09-26 09:07:03.307946+02	management	t	t	\N
-1466	2024-09-26 09:30:45.077639+02	management	t	t	\N
-1475	2024-09-26 09:42:42.544684+02	direct_edit	t	f	1
-1484	2024-09-26 10:11:34.742136+02	management	t	t	\N
-1493	2024-09-26 10:25:43.432671+02	management	t	t	\N
-1502	2024-09-26 11:49:38.352906+02	direct_edit	t	t	1
-1538	2024-09-26 12:04:34.371102+02	direct_edit	t	t	1
-1529	2024-09-26 12:03:13.271285+02	direct_edit	t	f	1
-1520	2024-09-26 12:01:44.385284+02	direct_edit	t	f	1
-1511	2024-09-26 12:00:21.846249+02	direct_edit	t	f	1
-1547	2024-09-26 12:15:54.970891+02	direct_edit	t	t	1
-1565	2024-10-14 09:43:30.556651+02	direct_edit	t	f	1
-1556	2024-10-14 09:42:25.236643+02	direct_edit	t	f	1
-1574	2024-10-14 09:59:13.073095+02	direct_edit	t	f	1
-1583	2024-10-14 10:06:52.733014+02	direct_edit	t	f	1
-1646	2024-10-14 11:15:48.453187+02	direct_edit	t	f	1
-1637	2024-10-14 11:13:19.559871+02	direct_edit	t	f	1
-1628	2024-10-14 10:37:22.579852+02	direct_edit	t	f	1
-1619	2024-10-14 10:36:31.780933+02	direct_edit	t	f	1
-1610	2024-10-14 10:35:59.622567+02	direct_edit	t	f	1
-1601	2024-10-14 10:32:57.760393+02	direct_edit	t	f	1
-1592	2024-10-14 10:26:29.247563+02	direct_edit	t	f	1
-1655	2024-10-14 11:22:02.24729+02	direct_edit	t	f	1
-1664	2024-10-14 11:38:02.7512+02	direct_edit	t	f	1
-1673	2024-10-14 11:47:00.962367+02	management	t	t	\N
-1682	2024-10-14 11:53:37.872442+02	direct_edit	t	f	1
-1691	2024-10-14 11:58:45.112624+02	management	t	t	\N
-1467	2024-09-26 09:31:54.371969+02	management	t	t	\N
-1476	2024-09-26 09:42:58.255982+02	management	t	t	\N
-1485	2024-09-26 10:16:09.237281+02	direct_edit	t	t	1
-1494	2024-09-26 10:26:20.93681+02	direct_edit	t	t	1
-1503	2024-09-26 11:49:47.073889+02	direct_edit	t	t	1
-1539	2024-09-26 12:05:06.833964+02	management	t	t	\N
-1530	2024-09-26 12:03:26.586659+02	direct_edit	t	f	1
-1521	2024-09-26 12:01:49.092846+02	direct_edit	t	f	1
-1512	2024-09-26 12:00:29.221148+02	direct_edit	t	f	1
-1548	2024-09-26 12:16:06.754154+02	management	t	t	\N
-1566	2024-10-14 09:47:08.014453+02	management	t	t	\N
-1557	2024-10-14 09:42:32.398147+02	direct_edit	t	f	1
-1575	2024-10-14 09:59:25.558589+02	management	t	t	\N
-1584	2024-10-14 10:07:00.817526+02	management	t	t	\N
-1647	2024-10-14 11:15:59.923983+02	direct_edit	t	f	1
-1638	2024-10-14 11:13:56.022618+02	direct_edit	t	f	1
-1629	2024-10-14 10:37:32.193879+02	direct_edit	t	f	1
-1620	2024-10-14 10:36:34.035541+02	direct_edit	t	f	1
-1611	2024-10-14 10:36:02.077794+02	direct_edit	t	f	1
-1602	2024-10-14 10:33:10.660786+02	direct_edit	t	f	1
-1593	2024-10-14 10:26:37.439362+02	direct_edit	t	f	1
-1656	2024-10-14 11:22:15.157528+02	direct_edit	t	f	1
-1665	2024-10-14 11:38:18.700802+02	management	t	t	\N
-1674	2024-10-14 11:48:16.32765+02	direct_edit	t	f	1
-1683	2024-10-14 11:54:10.855695+02	direct_edit	t	f	1
-1692	2024-10-14 11:59:22.143816+02	direct_edit	t	f	1
-1468	2024-09-26 09:35:43.672033+02	management	t	t	\N
-1477	2024-09-26 09:48:28.47175+02	direct_edit	t	t	1
-1486	2024-09-26 10:16:29.469269+02	direct_edit	t	t	1
-1495	2024-09-26 10:26:33.432951+02	direct_edit	t	t	1
-1504	2024-09-26 11:49:54.124328+02	direct_edit	t	t	1
-1531	2024-09-26 12:03:44.205265+02	direct_edit	t	f	1
-1522	2024-09-26 12:01:51.965332+02	direct_edit	t	f	1
-1513	2024-09-26 12:00:34.551498+02	direct_edit	t	f	1
-1540	2024-09-26 12:06:52.821557+02	direct_edit	t	t	1
-1558	2024-10-14 09:42:40.38506+02	direct_edit	t	f	1
-1549	2024-10-14 09:41:38.533546+02	direct_edit	t	f	1
-1567	2024-10-14 09:48:57.680573+02	direct_edit	t	f	1
-1576	2024-10-14 10:00:59.400395+02	direct_edit	t	f	1
-1585	2024-10-14 10:09:33.206094+02	direct_edit	t	f	1
-1648	2024-10-14 11:16:12.619615+02	direct_edit	t	f	1
-1639	2024-10-14 11:14:06.470297+02	direct_edit	t	f	1
-1630	2024-10-14 10:37:33.832333+02	direct_edit	t	f	1
-1621	2024-10-14 10:36:36.901217+02	direct_edit	t	f	1
-1612	2024-10-14 10:36:05.15603+02	direct_edit	t	f	1
-1603	2024-10-14 10:34:35.448399+02	direct_edit	t	t	1
-1594	2024-10-14 10:27:26.389106+02	direct_edit	t	f	1
-1657	2024-10-14 11:22:22.94894+02	management	t	t	\N
-1666	2024-10-14 11:39:13.008294+02	direct_edit	t	f	1
-1675	2024-10-14 11:48:22.655548+02	management	t	t	\N
-1684	2024-10-14 11:54:20.255639+02	management	t	t	\N
-1693	2024-10-14 11:59:30.122254+02	management	t	t	\N
-1469	2024-09-26 09:38:19.155151+02	direct_edit	t	t	1
-1478	2024-09-26 09:49:21.92287+02	direct_edit	t	t	1
-1487	2024-09-26 10:16:51.178104+02	direct_edit	t	t	1
-1496	2024-09-26 10:29:09.919491+02	direct_edit	t	t	1
-1505	2024-09-26 11:50:02.115388+02	direct_edit	t	t	1
-1532	2024-09-26 12:03:47.27035+02	direct_edit	t	f	1
-1523	2024-09-26 12:02:06.712112+02	direct_edit	t	f	1
-1514	2024-09-26 12:00:52.369591+02	direct_edit	t	f	1
-1541	2024-09-26 12:08:47.953783+02	management	t	t	\N
-1559	2024-10-14 09:42:44.694661+02	direct_edit	t	f	1
-1550	2024-10-14 09:41:40.995795+02	direct_edit	t	f	1
-1568	2024-10-14 09:49:07.499496+02	direct_edit	t	f	1
-1577	2024-10-14 10:01:12.515093+02	direct_edit	t	f	1
-1586	2024-10-14 10:09:41.771586+02	management	t	t	\N
-1649	2024-10-14 11:16:25.304951+02	management	t	t	\N
-1640	2024-10-14 11:14:13.628584+02	direct_edit	t	f	1
-1631	2024-10-14 10:37:36.911522+02	direct_edit	t	f	1
-1622	2024-10-14 10:36:48.994384+02	direct_edit	t	f	1
-1613	2024-10-14 10:36:09.042423+02	direct_edit	t	f	1
-1604	2024-10-14 10:34:42.819696+02	direct_edit	t	f	1
-1595	2024-10-14 10:27:30.891749+02	direct_edit	t	f	1
-1658	2024-10-14 11:24:46.051051+02	direct_edit	t	f	1
-1667	2024-10-14 11:41:08.674406+02	management	t	t	\N
-1676	2024-10-14 11:50:36.830452+02	direct_edit	t	f	1
-1685	2024-10-14 11:56:31.145849+02	direct_edit	t	f	1
-1470	2024-09-26 09:38:30.01308+02	management	t	t	\N
-1479	2024-09-26 09:49:39.561913+02	direct_edit	t	t	1
-1488	2024-09-26 10:17:03.261658+02	direct_edit	t	t	1
-1497	2024-09-26 10:29:52.871375+02	management	t	t	\N
-1506	2024-09-26 11:50:46.179522+02	direct_edit	t	f	1
-1533	2024-09-26 12:04:00.171117+02	direct_edit	t	f	1
-1524	2024-09-26 12:02:16.749619+02	direct_edit	t	f	1
-1515	2024-09-26 12:00:55.854845+02	direct_edit	t	f	1
-1542	2024-09-26 12:10:07.012276+02	direct_edit	t	t	1
-1560	2024-10-14 09:42:48.792562+02	direct_edit	t	f	1
-1551	2024-10-14 09:41:46.943402+02	direct_edit	t	t	1
-1569	2024-10-14 09:49:17.024828+02	direct_edit	t	f	1
-1578	2024-10-14 10:01:26.629597+02	direct_edit	t	f	1
-1587	2024-10-14 10:11:24.619805+02	direct_edit	t	f	1
-1641	2024-10-14 11:14:19.569443+02	direct_edit	t	f	1
-1632	2024-10-14 10:37:41.208229+02	direct_edit	t	f	1
-1623	2024-10-14 10:36:51.236409+02	direct_edit	t	f	1
-1614	2024-10-14 10:36:12.72773+02	direct_edit	t	f	1
-1605	2024-10-14 10:34:55.107253+02	direct_edit	t	f	1
-1596	2024-10-14 10:27:54.241424+02	direct_edit	t	f	1
-1650	2024-10-14 11:17:53.585831+02	direct_edit	t	f	1
-1659	2024-10-14 11:24:53.004838+02	management	t	t	\N
-1668	2024-10-14 11:44:10.394599+02	direct_edit	t	f	1
-1677	2024-10-14 11:50:44.846528+02	management	t	t	\N
-1686	2024-10-14 11:56:44.050708+02	direct_edit	t	f	1
-1471	2024-09-26 09:38:57.446861+02	direct_edit	t	f	1
-1480	2024-09-26 09:50:10.845706+02	direct_edit	t	t	1
-1489	2024-09-26 10:17:11.45662+02	direct_edit	t	t	1
-1498	2024-09-26 11:40:18.444027+02	direct_edit	t	t	1
-1507	2024-09-26 11:57:56.001745+02	management	t	t	\N
-1534	2024-09-26 12:04:06.518797+02	direct_edit	t	f	1
-1525	2024-09-26 12:02:39.690126+02	direct_edit	t	f	1
-1516	2024-09-26 12:00:59.94124+02	direct_edit	t	f	1
-1543	2024-09-26 12:11:36.710816+02	direct_edit	t	f	1
-1561	2024-10-14 09:42:58.211412+02	direct_edit	t	f	1
-1552	2024-10-14 09:41:54.924809+02	direct_edit	t	f	1
-1570	2024-10-14 09:49:25.460115+02	management	t	t	\N
-1579	2024-10-14 10:02:28.456476+02	direct_edit	t	t	1
-1588	2024-10-14 10:11:30.55195+02	management	t	t	\N
-1642	2024-10-14 11:14:49.056757+02	direct_edit	t	f	1
-1633	2024-10-14 10:37:43.872311+02	direct_edit	t	f	1
-1624	2024-10-14 10:36:53.284849+02	direct_edit	t	f	1
-1615	2024-10-14 10:36:17.643729+02	direct_edit	t	f	1
-1606	2024-10-14 10:35:35.872762+02	direct_edit	t	t	1
-1597	2024-10-14 10:28:08.375584+02	direct_edit	t	f	1
-1651	2024-10-14 11:18:04.222893+02	management	t	t	\N
-1660	2024-10-14 11:30:58.798038+02	direct_edit	t	f	1
-1669	2024-10-14 11:44:51.342677+02	management	t	t	\N
-1678	2024-10-14 11:51:21.268761+02	direct_edit	t	f	1
-1687	2024-10-14 11:57:08.407394+02	direct_edit	t	f	1
-1472	2024-09-26 09:39:07.477781+02	management	t	t	\N
-1481	2024-09-26 09:50:29.278483+02	direct_edit	t	t	1
-1490	2024-09-26 10:17:51.221735+02	direct_edit	t	t	1
-1499	2024-09-26 11:48:35.893205+02	management	t	t	\N
-1535	2024-09-26 12:04:10.823677+02	direct_edit	t	f	1
-1526	2024-09-26 12:02:43.997566+02	direct_edit	t	f	1
-1517	2024-09-26 12:01:27.179627+02	direct_edit	t	f	1
-1508	2024-09-26 11:58:46.616902+02	direct_edit	t	t	1
-1544	2024-09-26 12:13:38.548988+02	direct_edit	t	t	1
-1562	2024-10-14 09:43:01.282515+02	direct_edit	t	f	1
-1553	2024-10-14 09:42:02.09414+02	direct_edit	t	f	1
-1571	2024-10-14 09:58:34.540077+02	direct_edit	t	f	1
-1580	2024-10-14 10:02:46.362294+02	management	t	t	\N
-1643	2024-10-14 11:15:06.874703+02	direct_edit	t	f	1
-1634	2024-10-14 11:12:47.203034+02	direct_edit	t	f	1
-1625	2024-10-14 10:36:57.176022+02	direct_edit	t	f	1
-1616	2024-10-14 10:36:20.722192+02	direct_edit	t	f	1
-1607	2024-10-14 10:35:39.759403+02	direct_edit	t	t	1
-1598	2024-10-14 10:28:18.40645+02	direct_edit	t	f	1
-1589	2024-10-14 10:14:31.198129+02	direct_edit	t	f	1
-1652	2024-10-14 11:18:41.316411+02	direct_edit	t	f	1
-1661	2024-10-14 11:31:06.359922+02	management	t	t	\N
-1670	2024-10-14 11:46:33.115552+02	direct_edit	t	f	1
-1679	2024-10-14 11:51:33.620681+02	management	t	t	\N
-1688	2024-10-14 11:57:23.575567+02	direct_edit	t	f	1
-1473	2024-09-26 09:40:45.156097+02	management	t	t	\N
-1482	2024-09-26 09:54:22.979359+02	direct_edit	t	t	1
-1491	2024-09-26 10:18:23.962267+02	direct_edit	t	t	1
-1500	2024-09-26 11:49:21.765432+02	direct_edit	t	t	1
-1536	2024-09-26 12:04:14.711941+02	direct_edit	t	f	1
-1527	2024-09-26 12:02:46.857999+02	direct_edit	t	f	1
-1518	2024-09-26 12:01:30.865264+02	direct_edit	t	f	1
-1509	2024-09-26 11:58:56.65741+02	direct_edit	t	t	1
-1545	2024-09-26 12:13:50.617381+02	direct_edit	t	t	1
-1563	2024-10-14 09:43:11.52314+02	direct_edit	t	f	1
-1554	2024-10-14 09:42:13.562517+02	direct_edit	t	f	1
-1572	2024-10-14 09:58:51.157162+02	direct_edit	t	f	1
-1581	2024-10-14 10:05:56.745213+02	direct_edit	t	t	1
-1644	2024-10-14 11:15:20.599362+02	direct_edit	t	f	1
-1635	2024-10-14 11:12:53.139439+02	direct_edit	t	f	1
-1626	2024-10-14 10:37:06.806701+02	direct_edit	t	f	1
-1617	2024-10-14 10:36:26.046949+02	direct_edit	t	f	1
-1608	2024-10-14 10:35:44.023856+02	direct_edit	t	f	1
-1599	2024-10-14 10:28:42.181576+02	direct_edit	t	f	1
-1590	2024-10-14 10:26:19.20971+02	direct_edit	t	f	1
-1653	2024-10-14 11:18:50.755437+02	management	t	t	\N
-1662	2024-10-14 11:32:48.402875+02	direct_edit	t	f	1
-1671	2024-10-14 11:46:41.322179+02	direct_edit	t	f	1
-1680	2024-10-14 11:52:39.090567+02	direct_edit	t	f	1
-1689	2024-10-14 11:57:34.040624+02	management	t	t	\N
-1474	2024-09-26 09:42:29.674239+02	direct_edit	t	t	1
-1483	2024-09-26 09:58:04.543571+02	management	t	t	\N
-1492	2024-09-26 10:18:33.581381+02	direct_edit	t	t	1
-1501	2024-09-26 11:49:31.389063+02	direct_edit	t	t	1
-1537	2024-09-26 12:04:18.193127+02	direct_edit	t	f	1
-1528	2024-09-26 12:03:00.16993+02	direct_edit	t	f	1
-1519	2024-09-26 12:01:38.647719+02	direct_edit	t	f	1
-1510	2024-09-26 12:00:12.015625+02	direct_edit	t	f	1
-1546	2024-09-26 12:14:33.200347+02	management	t	t	\N
-1564	2024-10-14 09:43:15.62323+02	direct_edit	t	f	1
-1555	2024-10-14 09:42:21.134923+02	direct_edit	t	f	1
-1573	2024-10-14 09:58:55.666249+02	direct_edit	t	f	1
-1582	2024-10-14 10:06:10.672704+02	management	t	t	\N
-1645	2024-10-14 11:15:38.420506+02	direct_edit	t	f	1
-1636	2024-10-14 11:13:09.52928+02	direct_edit	t	f	1
-1627	2024-10-14 10:37:16.430538+02	direct_edit	t	f	1
-1618	2024-10-14 10:36:28.301877+02	direct_edit	t	f	1
-1609	2024-10-14 10:35:55.32481+02	direct_edit	t	t	1
-1600	2024-10-14 10:32:50.384939+02	direct_edit	t	f	1
-1591	2024-10-14 10:26:23.104212+02	direct_edit	t	f	1
-1654	2024-10-14 11:21:43.836395+02	direct_edit	t	f	1
-1663	2024-10-14 11:37:44.111677+02	direct_edit	t	t	1
-1672	2024-10-14 11:46:51.753904+02	direct_edit	t	f	1
-1681	2024-10-14 11:52:47.471178+02	management	t	t	\N
-1690	2024-10-14 11:58:36.302143+02	direct_edit	t	f	1
-1465	2024-09-26 09:07:49.438347+02	management	t	t	\N
-1694	2024-10-14 12:11:32.671043+02	management	t	t	\N
-1696	2024-10-14 12:23:51.222383+02	management	t	t	\N
-1695	2024-10-14 12:23:43.84118+02	direct_edit	t	f	1
-1699	2024-10-14 12:27:01.543045+02	management	t	t	\N
-1698	2024-10-14 12:26:54.099375+02	direct_edit	t	f	1
-1697	2024-10-14 12:25:00.434511+02	direct_edit	t	f	1
-1700	2024-10-14 12:35:23.941986+02	management	t	t	\N
-1702	2024-10-14 12:35:38.393384+02	management	t	t	\N
-1701	2024-10-14 12:35:32.664991+02	direct_edit	t	f	1
-1704	2024-10-14 12:42:51.211+02	management	t	t	\N
-1703	2024-10-14 12:42:42.736223+02	direct_edit	t	f	1
-1705	2024-10-14 12:44:39.470984+02	management	t	t	\N
-1708	2024-10-14 12:48:06.994629+02	management	t	t	\N
-1707	2024-10-14 12:47:59.978441+02	direct_edit	t	f	1
-1706	2024-10-14 12:45:22.311998+02	direct_edit	t	f	1
-1715	2024-10-14 12:54:23.789031+02	management	t	t	\N
-1714	2024-10-14 12:53:54.304584+02	direct_edit	t	f	1
-1713	2024-10-14 12:53:24.396856+02	direct_edit	t	f	1
-1712	2024-10-14 12:52:59.410632+02	direct_edit	t	f	1
-1711	2024-10-14 12:50:59.146135+02	direct_edit	t	f	1
-1710	2024-10-14 12:50:26.011795+02	direct_edit	t	f	1
-1709	2024-10-14 12:49:52.428081+02	direct_edit	t	f	1
-1718	2024-10-14 14:20:16.611694+02	management	t	t	\N
-1717	2024-10-14 14:20:09.09036+02	direct_edit	t	f	1
-1716	2024-10-14 14:19:37.95791+02	direct_edit	t	f	1
-1719	2024-10-14 14:22:02.195387+02	management	t	t	\N
-1723	2024-10-14 14:30:31.691898+02	management	t	t	\N
-1722	2024-10-14 14:29:01.759267+02	direct_edit	t	t	1
-1721	2024-10-14 14:28:17.949207+02	direct_edit	t	t	1
-1720	2024-10-14 14:27:25.927843+02	direct_edit	t	t	1
-1725	2024-10-14 14:31:30.893196+02	management	t	t	\N
-1724	2024-10-14 14:31:17.535758+02	direct_edit	t	t	1
-1728	2024-10-14 14:32:27.748725+02	management	t	t	\N
-1727	2024-10-14 14:32:20.084137+02	direct_edit	t	t	1
-1726	2024-10-14 14:32:14.473308+02	direct_edit	t	t	1
-1730	2024-10-14 14:36:00.833629+02	management	t	t	\N
-1729	2024-10-14 14:35:14.527524+02	direct_edit	t	t	1
-1739	2024-10-14 14:40:18.251126+02	management	t	t	\N
-1738	2024-10-14 14:40:10.044146+02	direct_edit	t	f	1
-1737	2024-10-14 14:39:50.589335+02	direct_edit	t	f	1
-1736	2024-10-14 14:39:34.197076+02	direct_edit	t	f	1
-1735	2024-10-14 14:39:23.352926+02	direct_edit	t	f	1
-1734	2024-10-14 14:39:01.422917+02	direct_edit	t	f	1
-1733	2024-10-14 14:37:02.267928+02	direct_edit	t	f	1
-1732	2024-10-14 14:36:53.043007+02	direct_edit	t	f	1
-1731	2024-10-14 14:36:48.538728+02	direct_edit	t	t	1
-1742	2024-10-14 14:48:23.395417+02	management	t	t	\N
-1741	2024-10-14 14:44:17.439792+02	direct_edit	t	t	1
-1740	2024-10-14 14:44:09.447739+02	direct_edit	t	t	1
-1743	2024-10-14 14:48:34.637638+02	management	t	t	\N
-1745	2024-10-14 14:54:08.270301+02	management	t	t	\N
-1744	2024-10-14 14:52:21.005875+02	direct_edit	t	t	1
-1749	2024-10-14 14:56:39.387991+02	management	t	t	\N
-1748	2024-10-14 14:56:32.352144+02	direct_edit	t	t	1
-1747	2024-10-14 14:55:09.746827+02	direct_edit	t	t	1
-1746	2024-10-14 14:54:37.171423+02	direct_edit	t	f	1
-1755	2024-10-14 14:59:57.859694+02	management	t	t	\N
-1754	2024-10-14 14:58:48.262633+02	direct_edit	t	f	1
-1753	2024-10-14 14:58:22.049434+02	direct_edit	t	f	1
-1752	2024-10-14 14:57:49.279354+02	direct_edit	t	f	1
-1751	2024-10-14 14:57:33.507269+02	direct_edit	t	f	1
-1750	2024-10-14 14:57:24.493498+02	direct_edit	t	f	1
-1757	2024-10-24 15:16:51.718189+02	management	t	t	\N
-1756	2024-10-18 11:49:53.311021+02	direct_edit	t	f	1
-1761	2024-10-24 15:20:06.907445+02	management	t	t	\N
-1760	2024-10-24 15:19:56.019943+02	direct_edit	t	t	1
-1759	2024-10-24 15:18:53.332804+02	direct_edit	t	f	1
-1758	2024-10-24 15:17:52.697184+02	direct_edit	t	f	1
-1766	2024-10-24 15:24:02.57539+02	management	t	t	\N
-1765	2024-10-24 15:23:54.202272+02	direct_edit	t	t	1
-1764	2024-10-24 15:23:14.444768+02	direct_edit	t	f	1
-1763	2024-10-24 15:22:22.251781+02	direct_edit	t	t	1
-1762	2024-10-24 15:21:45.137678+02	direct_edit	t	t	1
-1773	2024-10-24 15:29:43.594563+02	management	t	t	\N
-1772	2024-10-24 15:29:36.025806+02	direct_edit	t	f	1
-1771	2024-10-24 15:29:17.595969+02	direct_edit	t	f	1
-1770	2024-10-24 15:28:59.98065+02	direct_edit	t	f	1
-1769	2024-10-24 15:28:29.852193+02	direct_edit	t	f	1
-1768	2024-10-24 15:28:22.598123+02	direct_edit	t	f	1
-1767	2024-10-24 15:28:09.564467+02	direct_edit	t	f	1
-1820	2024-10-25 12:03:45.949335+02	management	t	t	\N
-1819	2024-10-25 12:03:24.25572+02	direct_edit	t	f	1
-1818	2024-10-25 12:03:18.725972+02	direct_edit	t	t	1
-1817	2024-10-25 12:03:07.249371+02	direct_edit	t	f	1
-1816	2024-10-25 12:02:38.999621+02	direct_edit	t	f	1
-1815	2024-10-25 12:02:28.138342+02	direct_edit	t	f	1
-1814	2024-10-25 12:02:18.922037+02	direct_edit	t	f	1
-1813	2024-10-25 12:02:16.260526+02	direct_edit	t	f	1
-1812	2024-10-25 12:02:13.400114+02	direct_edit	t	f	1
-1811	2024-10-25 12:02:09.706571+02	direct_edit	t	f	1
-1810	2024-10-25 12:01:58.851573+02	direct_edit	t	f	1
-1809	2024-10-25 12:01:54.961302+02	direct_edit	t	f	1
-1808	2024-10-25 12:01:51.068408+02	direct_edit	t	f	1
-1807	2024-10-25 12:01:40.216588+02	direct_edit	t	f	1
-1806	2024-10-25 12:01:33.052438+02	direct_edit	t	f	1
-1805	2024-10-25 12:01:25.674626+02	direct_edit	t	f	1
-1804	2024-10-25 12:01:12.970707+02	direct_edit	t	t	1
-1803	2024-10-25 12:01:09.082121+02	direct_edit	t	t	1
-1802	2024-10-25 12:00:55.156445+02	direct_edit	t	f	1
-1801	2024-10-25 12:00:50.650989+02	direct_edit	t	f	1
-1800	2024-10-25 12:00:34.671144+02	direct_edit	t	f	1
-1799	2024-10-25 12:00:29.962403+02	direct_edit	t	f	1
-1798	2024-10-25 12:00:25.456775+02	direct_edit	t	f	1
-1797	2024-10-25 12:00:11.325123+02	direct_edit	t	f	1
-1796	2024-10-25 12:00:03.757279+02	direct_edit	t	f	1
-1795	2024-10-25 12:00:01.296026+02	direct_edit	t	f	1
-1794	2024-10-25 11:59:56.994033+02	direct_edit	t	f	1
-1793	2024-10-25 11:59:37.327769+02	direct_edit	t	f	1
-1792	2024-10-25 11:59:22.991846+02	direct_edit	t	f	1
-1791	2024-10-25 11:58:53.711551+02	direct_edit	t	f	1
-1790	2024-10-25 11:58:50.45456+02	direct_edit	t	f	1
-1789	2024-10-25 11:58:46.136691+02	direct_edit	t	f	1
-1788	2024-10-25 11:58:37.323695+02	direct_edit	t	f	1
-1787	2024-10-25 11:58:26.681188+02	direct_edit	t	f	1
-1786	2024-10-25 11:58:20.533115+02	direct_edit	t	f	1
-1785	2024-10-25 11:57:57.180209+02	direct_edit	t	t	1
-1784	2024-10-25 11:57:36.728002+02	direct_edit	t	t	1
-1783	2024-10-25 11:56:45.337499+02	direct_edit	t	t	1
-1782	2024-10-25 11:55:27.487324+02	direct_edit	t	t	1
-1781	2024-10-25 11:54:14.962113+02	direct_edit	t	t	1
-1780	2024-10-25 11:53:59.333346+02	direct_edit	t	t	1
-1779	2024-10-25 11:52:11.513594+02	direct_edit	t	t	1
-1778	2024-10-25 11:50:00.644331+02	direct_edit	t	t	1
-1777	2024-10-25 11:49:30.695085+02	direct_edit	t	t	1
-1776	2024-10-25 11:49:25.774557+02	direct_edit	t	t	1
-1775	2024-10-25 11:49:07.764364+02	direct_edit	t	t	1
-1774	2024-10-25 11:48:15.789307+02	direct_edit	t	t	1
-1821	2024-10-25 12:05:31.268637+02	direct_edit	f	t	1
+210	2024-08-26 16:29:07.884+00	direct_edit	t	t	1
+209	2024-08-26 16:28:00.699+00	direct_edit	t	t	1
+211	2024-08-27 10:08:59.004972+00	management	t	f	\N
+212	2024-08-27 10:09:19.465461+00	management	t	f	\N
+213	2024-08-27 10:13:53.88039+00	direct_edit	t	f	1
+214	2024-08-27 10:14:57.981204+00	direct_edit	t	f	1
+215	2024-08-27 10:19:11.329148+00	direct_edit	t	t	1
+217	2024-08-29 09:18:33.55282+00	control_panel	t	t	1
+216	2024-08-29 09:13:55.910267+00	direct_edit	t	t	1
+224	2024-08-29 09:26:25.481507+00	direct_edit	t	t	1
+223	2024-08-29 09:25:13.004416+00	direct_edit	t	f	1
+222	2024-08-29 09:25:05.815454+00	direct_edit	t	t	1
+221	2024-08-29 09:24:38.776899+00	direct_edit	t	t	1
+220	2024-08-29 09:24:04.990566+00	direct_edit	t	t	1
+219	2024-08-29 09:23:11.100271+00	direct_edit	t	f	1
+218	2024-08-29 09:21:00.436979+00	direct_edit	t	f	1
+226	2024-08-29 09:28:42.264428+00	direct_edit	t	t	1
+225	2024-08-29 09:28:04.595118+00	direct_edit	t	t	1
+228	2024-08-29 09:30:34.905809+00	direct_edit	t	t	1
+227	2024-08-29 09:29:52.750463+00	direct_edit	t	t	1
+230	2024-08-29 09:33:17.930903+00	direct_edit	t	t	1
+229	2024-08-29 09:32:58.921582+00	direct_edit	t	t	1
+233	2024-08-29 09:35:39.654214+00	direct_edit	t	t	1
+232	2024-08-29 09:35:16.548169+00	direct_edit	t	t	1
+231	2024-08-29 09:34:20.803056+00	direct_edit	t	t	1
+238	2024-08-29 09:39:04.878827+00	direct_edit	t	t	1
+237	2024-08-29 09:38:39.870322+00	direct_edit	t	f	1
+236	2024-08-29 09:38:14.712598+00	direct_edit	t	t	1
+235	2024-08-29 09:37:48.887054+00	direct_edit	t	t	1
+234	2024-08-29 09:37:25.335645+00	direct_edit	t	t	1
+241	2024-08-29 09:41:22.091492+00	direct_edit	t	f	1
+240	2024-08-29 09:41:09.392881+00	direct_edit	t	f	1
+239	2024-08-29 09:40:47.681107+00	direct_edit	t	f	1
+243	2024-08-29 09:43:06.952599+00	direct_edit	t	f	1
+242	2024-08-29 09:42:42.579501+00	direct_edit	t	f	1
+248	2024-08-29 09:50:43.687998+00	direct_edit	t	f	1
+247	2024-08-29 09:49:54.703769+00	direct_edit	t	t	1
+246	2024-08-29 09:45:51.81963+00	direct_edit	t	t	1
+245	2024-08-29 09:45:43.221388+00	direct_edit	t	t	1
+244	2024-08-29 09:44:03.545467+00	direct_edit	t	f	1
+250	2024-08-29 09:52:50.042778+00	direct_edit	t	t	1
+249	2024-08-29 09:52:07.250959+00	direct_edit	t	f	1
+252	2024-08-29 09:56:04.807276+00	direct_edit	t	t	1
+251	2024-08-29 09:55:11.149843+00	direct_edit	t	t	1
+253	2024-08-29 09:58:45.59235+00	direct_edit	t	t	1
+263	2024-08-29 10:10:13.499096+00	direct_edit	t	f	1
+262	2024-08-29 10:09:58.138119+00	direct_edit	t	f	1
+261	2024-08-29 10:09:50.15106+00	direct_edit	t	f	1
+260	2024-08-29 10:09:28.440383+00	direct_edit	t	f	1
+259	2024-08-29 10:08:52.800394+00	direct_edit	t	t	1
+258	2024-08-29 10:03:57.066581+00	direct_edit	t	t	1
+257	2024-08-29 10:03:33.10395+00	direct_edit	t	t	1
+256	2024-08-29 10:03:16.565277+00	direct_edit	t	t	1
+255	2024-08-29 10:02:57.69302+00	direct_edit	t	t	1
+254	2024-08-29 10:02:38.237035+00	direct_edit	t	t	1
+274	2024-08-29 10:25:28.979404+00	direct_edit	t	f	1
+273	2024-08-29 10:25:22.62013+00	direct_edit	t	f	1
+272	2024-08-29 10:24:57.442782+00	direct_edit	t	f	1
+271	2024-08-29 10:24:50.46408+00	direct_edit	t	f	1
+270	2024-08-29 10:24:11.962458+00	direct_edit	t	t	1
+269	2024-08-29 10:23:46.154768+00	direct_edit	t	t	1
+268	2024-08-29 10:23:38.376962+00	direct_edit	t	t	1
+267	2024-08-29 10:23:25.265377+00	direct_edit	t	t	1
+266	2024-08-29 10:23:09.084656+00	direct_edit	t	t	1
+265	2024-08-29 10:23:04.380568+00	direct_edit	t	t	1
+264	2024-08-29 10:22:53.13712+00	direct_edit	t	t	1
+275	2024-08-29 10:28:18.446324+00	direct_edit	t	f	1
+282	2024-08-29 10:49:43.078575+00	direct_edit	t	f	1
+281	2024-08-29 10:49:37.142884+00	direct_edit	t	f	1
+280	2024-08-29 10:49:31.622177+00	direct_edit	t	f	1
+279	2024-08-29 10:49:23.006829+00	direct_edit	t	f	1
+278	2024-08-29 10:49:16.448651+00	direct_edit	t	f	1
+277	2024-08-29 10:49:08.6712+00	direct_edit	t	f	1
+276	2024-08-29 10:48:39.777997+00	direct_edit	t	f	1
+283	2024-08-29 10:51:13.586654+00	direct_edit	t	f	1
+284	2024-08-29 10:54:27.127752+00	direct_edit	t	f	1
+285	2024-09-04 14:17:36.439755+00	direct_edit	t	t	1
+291	2024-09-06 07:49:06.147603+00	direct_edit	t	t	1
+290	2024-09-06 07:48:02.455722+00	direct_edit	t	t	1
+289	2024-09-06 07:47:54.260887+00	direct_edit	t	t	1
+288	2024-09-06 07:47:45.454026+00	direct_edit	t	t	1
+287	2024-09-06 07:47:33.783657+00	direct_edit	t	t	1
+286	2024-09-06 07:47:16.576667+00	direct_edit	t	t	1
+292	2024-09-06 07:50:25.234843+00	direct_edit	t	t	1
+302	2024-09-06 15:28:30.847255+00	direct_edit	t	t	1
+301	2024-09-06 15:27:17.120685+00	direct_edit	t	t	1
+300	2024-09-06 15:27:07.071526+00	direct_edit	t	f	1
+299	2024-09-06 15:26:38.412071+00	direct_edit	t	t	1
+298	2024-09-06 15:26:20.069538+00	direct_edit	t	f	1
+297	2024-09-06 15:25:42.704835+00	direct_edit	t	t	1
+296	2024-09-06 15:25:12.19151+00	direct_edit	t	f	1
+295	2024-09-06 15:25:01.734519+00	direct_edit	t	f	1
+294	2024-09-06 15:23:15.453189+00	direct_edit	t	t	1
+293	2024-09-06 15:23:07.672316+00	direct_edit	t	t	1
+1451	2024-09-17 09:58:51.286769+00	direct_edit	t	t	1
+1463	2024-09-24 10:04:34.216787+00	management	t	t	\N
+343	2024-09-06 15:45:12.369938+00	direct_edit	t	t	1
+342	2024-09-06 15:44:39.977339+00	direct_edit	t	t	1
+341	2024-09-06 15:43:49.834548+00	direct_edit	t	t	1
+340	2024-09-06 15:41:42.21649+00	direct_edit	t	f	1
+339	2024-09-06 15:41:39.146591+00	direct_edit	t	f	1
+338	2024-09-06 15:41:35.192818+00	direct_edit	t	f	1
+337	2024-09-06 15:41:28.49275+00	direct_edit	t	f	1
+336	2024-09-06 15:40:55.116517+00	direct_edit	t	f	1
+335	2024-09-06 15:40:52.249014+00	direct_edit	t	f	1
+334	2024-09-06 15:40:46.721944+00	direct_edit	t	f	1
+333	2024-09-06 15:40:39.957981+00	direct_edit	t	f	1
+332	2024-09-06 15:40:34.017518+00	direct_edit	t	f	1
+331	2024-09-06 15:40:29.918907+00	direct_edit	t	f	1
+330	2024-09-06 15:40:25.412466+00	direct_edit	t	f	1
+329	2024-09-06 15:40:07.586805+00	direct_edit	t	t	1
+328	2024-09-06 15:39:58.370542+00	direct_edit	t	t	1
+327	2024-09-06 15:39:51.615625+00	direct_edit	t	t	1
+326	2024-09-06 15:39:44.252296+00	direct_edit	t	t	1
+325	2024-09-06 15:39:36.05012+00	direct_edit	t	t	1
+324	2024-09-06 15:39:28.67254+00	direct_edit	t	t	1
+323	2024-09-06 15:39:20.688748+00	direct_edit	t	t	1
+322	2024-09-06 15:39:12.4951+00	direct_edit	t	t	1
+321	2024-09-06 15:39:05.125222+00	direct_edit	t	t	1
+320	2024-09-06 15:38:58.978201+00	direct_edit	t	t	1
+319	2024-09-06 15:38:52.424022+00	direct_edit	t	t	1
+318	2024-09-06 15:38:45.25631+00	direct_edit	t	t	1
+317	2024-09-06 15:38:37.47802+00	direct_edit	t	t	1
+316	2024-09-06 15:38:30.719377+00	direct_edit	t	t	1
+315	2024-09-06 15:38:23.554845+00	direct_edit	t	t	1
+314	2024-09-06 15:38:16.584641+00	direct_edit	t	t	1
+313	2024-09-06 15:37:58.567224+00	direct_edit	t	t	1
+312	2024-09-06 15:37:42.597163+00	direct_edit	t	t	1
+311	2024-09-06 15:37:27.229276+00	direct_edit	t	t	1
+310	2024-09-06 15:37:17.406104+00	direct_edit	t	t	1
+309	2024-09-06 15:36:49.97444+00	direct_edit	t	t	1
+308	2024-09-06 15:35:20.876125+00	direct_edit	t	f	1
+307	2024-09-06 15:32:59.171721+00	direct_edit	t	t	1
+306	2024-09-06 15:32:43.78461+00	direct_edit	t	t	1
+305	2024-09-06 15:32:28.731979+00	direct_edit	t	t	1
+304	2024-09-06 15:32:06.937298+00	direct_edit	t	f	1
+303	2024-09-06 15:31:16.321467+00	direct_edit	t	f	1
+345	2024-09-06 15:50:36.751498+00	direct_edit	t	f	1
+344	2024-09-06 15:50:01.149004+00	direct_edit	t	t	1
+352	2024-09-07 13:43:01.626708+00	direct_edit	t	f	1
+351	2024-09-07 13:42:57.534366+00	direct_edit	t	f	1
+350	2024-09-07 13:42:48.31167+00	direct_edit	t	f	1
+349	2024-09-07 13:42:42.988137+00	direct_edit	t	t	1
+348	2024-09-07 13:42:29.676839+00	direct_edit	t	t	1
+347	2024-09-07 13:42:22.290238+00	direct_edit	t	f	1
+346	2024-09-07 13:41:57.104812+00	direct_edit	t	t	1
+359	2024-09-07 13:45:13.724763+00	direct_edit	t	f	1
+358	2024-09-07 13:45:11.879539+00	direct_edit	t	f	1
+357	2024-09-07 13:45:10.0371+00	direct_edit	t	f	1
+356	2024-09-07 13:45:02.871721+00	direct_edit	t	f	1
+355	2024-09-07 13:44:59.794215+00	direct_edit	t	f	1
+354	2024-09-07 13:44:48.941889+00	direct_edit	t	t	1
+353	2024-09-07 13:44:40.756985+00	direct_edit	t	f	1
+360	2024-09-07 13:46:44.063729+00	direct_edit	t	t	1
+361	2024-09-07 13:48:12.30391+00	direct_edit	t	t	1
+362	2024-09-07 13:49:23.4101+00	direct_edit	t	t	1
+381	2024-09-07 15:20:12.780091+00	direct_edit	t	f	1
+380	2024-09-07 15:20:01.312732+00	direct_edit	t	f	1
+379	2024-09-07 15:19:57.622271+00	direct_edit	t	f	1
+378	2024-09-07 15:19:44.30942+00	direct_edit	t	f	1
+377	2024-09-07 15:19:28.943039+00	direct_edit	t	f	1
+376	2024-09-07 15:17:29.760583+00	direct_edit	t	f	1
+375	2024-09-07 15:17:26.282425+00	direct_edit	t	f	1
+374	2024-09-07 15:17:21.766637+00	direct_edit	t	f	1
+373	2024-09-07 15:17:14.193557+00	direct_edit	t	f	1
+372	2024-09-07 15:16:49.208231+00	direct_edit	t	f	1
+371	2024-09-07 15:16:44.701281+00	direct_edit	t	f	1
+370	2024-09-07 15:16:36.505509+00	direct_edit	t	f	1
+369	2024-09-07 15:16:19.924697+00	direct_edit	t	f	1
+368	2024-09-07 15:15:55.34475+00	direct_edit	t	f	1
+367	2024-09-07 15:15:44.920176+00	direct_edit	t	f	1
+366	2024-09-07 15:14:55.7438+00	direct_edit	t	t	1
+365	2024-09-07 15:14:15.073165+00	direct_edit	t	t	1
+364	2024-09-07 15:14:00.6651+00	direct_edit	t	t	1
+363	2024-09-07 15:12:46.537393+00	direct_edit	t	t	1
+382	2024-09-07 15:24:48.242937+00	direct_edit	t	t	1
+383	2024-09-08 13:04:23.072218+00	direct_edit	t	f	1
+384	2024-09-08 13:14:51.180815+00	direct_edit	t	f	1
+385	2024-09-08 13:15:09.849713+00	management	t	f	\N
+386	2024-09-08 13:16:15.996417+00	direct_edit	t	t	1
+393	2024-09-08 13:21:59.630012+00	direct_edit	t	t	1
+392	2024-09-08 13:21:33.834162+00	direct_edit	t	t	1
+391	2024-09-08 13:20:53.916275+00	direct_edit	t	t	1
+390	2024-09-08 13:19:34.427024+00	direct_edit	t	t	1
+389	2024-09-08 13:19:30.126553+00	direct_edit	t	t	1
+388	2024-09-08 13:19:26.241253+00	direct_edit	t	t	1
+387	2024-09-08 13:19:21.730552+00	direct_edit	t	t	1
+397	2024-09-08 13:31:06.252171+00	direct_edit	t	t	1
+396	2024-09-08 13:30:22.245382+00	direct_edit	t	t	1
+395	2024-09-08 13:28:23.668135+00	direct_edit	t	t	1
+394	2024-09-08 13:26:31.02319+00	direct_edit	t	t	1
+404	2024-09-08 13:40:14.331678+00	direct_edit	t	f	1
+403	2024-09-08 13:39:39.482799+00	direct_edit	t	t	1
+402	2024-09-08 13:39:13.094796+00	direct_edit	t	t	1
+401	2024-09-08 13:38:12.688373+00	direct_edit	t	t	1
+400	2024-09-08 13:33:14.247243+00	direct_edit	t	t	1
+399	2024-09-08 13:32:36.363492+00	direct_edit	t	f	1
+398	2024-09-08 13:32:30.633935+00	direct_edit	t	t	1
+405	2024-09-08 13:40:53.892833+00	management	t	f	\N
+406	2024-09-08 13:44:43.245159+00	management	t	f	\N
+408	2024-09-08 14:01:34.830472+00	management	t	f	\N
+407	2024-09-08 14:01:23.061072+00	direct_edit	t	t	1
+410	2024-09-08 14:04:15.562542+00	management	t	f	\N
+409	2024-09-08 14:04:03.248852+00	direct_edit	t	t	1
+412	2024-09-08 14:06:05.753489+00	management	t	f	\N
+411	2024-09-08 14:05:32.747845+00	direct_edit	t	t	1
+414	2024-09-08 14:07:55.085302+00	direct_edit	t	t	1
+413	2024-09-08 14:07:10.447539+00	direct_edit	t	t	1
+415	2024-09-08 14:09:40.963861+00	direct_edit	t	t	1
+416	2024-09-08 14:13:20.719936+00	direct_edit	t	t	1
+419	2024-09-08 14:16:06.405037+00	direct_edit	t	t	1
+418	2024-09-08 14:15:40.775285+00	direct_edit	t	t	1
+417	2024-09-08 14:15:03.119899+00	direct_edit	t	t	1
+420	2024-09-08 14:17:05.617823+00	management	t	f	\N
+422	2024-09-09 06:37:17.566215+00	direct_edit	t	t	1
+421	2024-09-09 06:36:57.6649+00	direct_edit	t	t	1
+428	2024-09-09 06:46:05.994759+00	management	t	f	\N
+427	2024-09-09 06:44:29.459471+00	direct_edit	t	t	1
+426	2024-09-09 06:44:20.049891+00	direct_edit	t	t	1
+425	2024-09-09 06:44:15.327053+00	direct_edit	t	t	1
+424	2024-09-09 06:44:02.22251+00	direct_edit	t	t	1
+423	2024-09-09 06:43:54.850252+00	direct_edit	t	t	1
+429	2024-09-09 06:47:55.518215+00	management	t	f	\N
+430	2024-09-09 06:49:19.705936+00	direct_edit	t	t	1
+431	2024-09-09 06:51:46.579894+00	management	t	f	\N
+434	2024-09-09 06:53:44.896137+00	direct_edit	t	t	1
+433	2024-09-09 06:53:35.67678+00	direct_edit	t	t	1
+432	2024-09-09 06:53:20.752247+00	direct_edit	t	t	1
+435	2024-09-09 06:56:19.959336+00	direct_edit	t	t	1
+442	2024-09-09 07:25:29.971686+00	direct_edit	t	t	1
+441	2024-09-09 07:24:59.279486+00	direct_edit	t	t	1
+440	2024-09-09 07:24:24.263241+00	direct_edit	t	t	1
+439	2024-09-09 07:23:52.68741+00	direct_edit	t	t	1
+438	2024-09-09 07:23:17.474656+00	direct_edit	t	t	1
+437	2024-09-09 07:22:07.631007+00	direct_edit	t	t	1
+436	2024-09-09 07:20:46.323148+00	direct_edit	t	t	1
+444	2024-09-09 07:27:42.479752+00	direct_edit	t	t	1
+443	2024-09-09 07:26:57.015816+00	direct_edit	t	t	1
+452	2024-09-09 07:31:34.524747+00	direct_edit	t	f	1
+451	2024-09-09 07:31:25.920365+00	direct_edit	t	f	1
+450	2024-09-09 07:30:46.398787+00	direct_edit	t	f	1
+449	2024-09-09 07:30:31.45453+00	direct_edit	t	f	1
+448	2024-09-09 07:30:26.742663+00	direct_edit	t	f	1
+447	2024-09-09 07:30:08.710049+00	direct_edit	t	f	1
+446	2024-09-09 07:30:04.660181+00	direct_edit	t	f	1
+445	2024-09-09 07:29:42.502925+00	direct_edit	t	t	1
+453	2024-09-09 07:33:19.990441+00	direct_edit	t	f	1
+454	2024-09-09 07:38:05.891486+00	direct_edit	t	f	1
+457	2024-09-09 07:41:53.062925+00	direct_edit	t	f	1
+456	2024-09-09 07:41:43.840339+00	direct_edit	t	f	1
+455	2024-09-09 07:41:32.580453+00	direct_edit	t	t	1
+459	2024-09-09 07:45:18.448552+00	direct_edit	t	f	1
+458	2024-09-09 07:45:05.797165+00	direct_edit	t	f	1
+462	2024-09-09 07:56:38.643113+00	management	t	f	\N
+461	2024-09-09 07:55:27.942423+00	direct_edit	t	t	1
+460	2024-09-09 07:55:19.551465+00	direct_edit	t	t	1
+466	2024-09-09 08:00:06.483721+00	direct_edit	t	f	1
+465	2024-09-09 07:59:54.601331+00	direct_edit	t	f	1
+464	2024-09-09 07:59:28.790191+00	direct_edit	t	f	1
+463	2024-09-09 07:57:29.873802+00	direct_edit	t	t	1
+468	2024-09-09 08:02:46.83677+00	direct_edit	t	f	1
+467	2024-09-09 08:02:35.782532+00	direct_edit	t	f	1
+469	2024-09-09 08:04:04.461798+00	direct_edit	t	f	1
+470	2024-09-09 08:04:19.910271+00	management	t	f	\N
+473	2024-09-09 08:07:16.244106+00	management	t	f	\N
+472	2024-09-09 08:06:46.052174+00	direct_edit	t	f	1
+471	2024-09-09 08:06:41.541636+00	direct_edit	t	f	1
+477	2024-09-09 08:16:12.052682+00	direct_edit	t	f	1
+476	2024-09-09 08:16:03.111476+00	direct_edit	t	f	1
+475	2024-09-09 08:15:53.284379+00	direct_edit	t	f	1
+474	2024-09-09 08:10:37.274052+00	direct_edit	t	t	1
+478	2024-09-09 08:19:10.094147+00	direct_edit	t	t	1
+485	2024-09-09 08:37:42.05259+00	management	t	f	\N
+484	2024-09-09 08:36:37.475212+00	direct_edit	t	t	1
+483	2024-09-09 08:35:27.65272+00	direct_edit	t	t	1
+482	2024-09-09 08:34:45.671364+00	direct_edit	t	t	1
+481	2024-09-09 08:34:07.579557+00	direct_edit	t	t	1
+480	2024-09-09 08:32:52.955664+00	direct_edit	t	t	1
+479	2024-09-09 08:31:10.824543+00	direct_edit	t	t	1
+487	2024-09-09 08:39:44.509942+00	management	t	f	\N
+486	2024-09-09 08:39:09.27074+00	direct_edit	t	t	1
+489	2024-09-09 08:41:34.626938+00	direct_edit	t	t	1
+488	2024-09-09 08:41:14.003561+00	direct_edit	t	t	1
+496	2024-09-09 08:54:47.832929+00	direct_edit	t	t	1
+495	2024-09-09 08:54:40.051725+00	direct_edit	t	t	1
+494	2024-09-09 08:54:18.534587+00	direct_edit	t	f	1
+493	2024-09-09 08:54:08.703531+00	direct_edit	t	f	1
+492	2024-09-09 08:52:59.117547+00	direct_edit	t	t	1
+491	2024-09-09 08:49:56.831755+00	direct_edit	t	t	1
+490	2024-09-09 08:46:58.644834+00	direct_edit	t	f	1
+501	2024-09-09 09:03:24.045831+00	management	t	f	\N
+500	2024-09-09 09:02:19.64621+00	direct_edit	t	t	1
+499	2024-09-09 09:01:08.354748+00	direct_edit	t	t	1
+498	2024-09-09 09:00:55.251079+00	direct_edit	t	t	1
+497	2024-09-09 09:00:30.296998+00	direct_edit	t	t	1
+510	2024-09-09 09:08:37.427351+00	management	t	f	\N
+509	2024-09-09 09:07:59.805377+00	direct_edit	t	t	1
+508	2024-09-09 09:07:52.025037+00	direct_edit	t	t	1
+507	2024-09-09 09:07:24.783785+00	direct_edit	t	t	1
+506	2024-09-09 09:07:09.426652+00	direct_edit	t	t	1
+505	2024-09-09 09:06:27.852913+00	direct_edit	t	t	1
+504	2024-09-09 09:06:09.011879+00	direct_edit	t	t	1
+503	2024-09-09 09:06:04.296966+00	direct_edit	t	t	1
+502	2024-09-09 09:05:54.878263+00	direct_edit	t	t	1
+518	2024-09-09 11:57:25.073455+00	management	t	f	\N
+517	2024-09-09 11:26:58.990248+00	direct_edit	t	t	1
+516	2024-09-09 11:26:46.299127+00	direct_edit	t	t	1
+515	2024-09-09 11:26:06.77042+00	direct_edit	t	t	1
+514	2024-09-09 11:25:49.766881+00	direct_edit	t	t	1
+513	2024-09-09 11:25:36.250635+00	direct_edit	t	t	1
+512	2024-09-09 11:25:05.939145+00	direct_edit	t	t	1
+511	2024-09-09 11:24:36.066279+00	direct_edit	t	t	1
+1453	2024-09-17 10:00:13.823186+00	direct_edit	t	t	1
+527	2024-09-09 12:00:51.062797+00	direct_edit	t	f	1
+526	2024-09-09 12:00:45.735306+00	direct_edit	t	f	1
+525	2024-09-09 12:00:42.260665+00	direct_edit	t	f	1
+524	2024-09-09 12:00:28.937938+00	direct_edit	t	f	1
+523	2024-09-09 12:00:24.22382+00	direct_edit	t	f	1
+522	2024-09-09 12:00:12.344409+00	direct_edit	t	f	1
+521	2024-09-09 11:59:42.466064+00	direct_edit	t	f	1
+520	2024-09-09 11:59:23.022119+00	direct_edit	t	t	1
+519	2024-09-09 11:58:34.450776+00	direct_edit	t	t	1
+531	2024-09-09 12:03:37.550135+00	direct_edit	t	t	1
+530	2024-09-09 12:03:24.238836+00	direct_edit	t	t	1
+529	2024-09-09 12:03:06.217063+00	direct_edit	t	t	1
+528	2024-09-09 12:02:54.135449+00	direct_edit	t	t	1
+544	2024-09-09 12:06:15.055296+00	direct_edit	t	f	1
+543	2024-09-09 12:06:12.187204+00	direct_edit	t	f	1
+542	2024-09-09 12:06:01.745036+00	direct_edit	t	f	1
+541	2024-09-09 12:05:59.494049+00	direct_edit	t	f	1
+540	2024-09-09 12:05:54.980294+00	direct_edit	t	f	1
+539	2024-09-09 12:05:51.708362+00	direct_edit	t	f	1
+538	2024-09-09 12:05:41.886527+00	direct_edit	t	f	1
+537	2024-09-09 12:05:39.213338+00	direct_edit	t	f	1
+536	2024-09-09 12:05:31.633572+00	direct_edit	t	f	1
+535	2024-09-09 12:05:29.793947+00	direct_edit	t	f	1
+534	2024-09-09 12:05:21.807729+00	direct_edit	t	f	1
+533	2024-09-09 12:05:15.66883+00	direct_edit	t	f	1
+532	2024-09-09 12:05:13.616362+00	direct_edit	t	f	1
+549	2024-09-09 12:08:20.195811+00	direct_edit	t	f	1
+548	2024-09-09 12:08:17.121137+00	direct_edit	t	f	1
+547	2024-09-09 12:08:14.455351+00	direct_edit	t	f	1
+546	2024-09-09 12:08:07.905102+00	direct_edit	t	f	1
+545	2024-09-09 12:07:59.918561+00	direct_edit	t	f	1
+550	2024-09-09 12:10:02.798039+00	direct_edit	t	f	1
+554	2024-09-09 12:33:11.19119+00	direct_edit	t	t	1
+553	2024-09-09 12:15:22.295487+00	direct_edit	t	f	1
+552	2024-09-09 12:13:40.28748+00	direct_edit	t	t	1
+551	2024-09-09 12:13:30.047792+00	direct_edit	t	t	1
+555	2024-09-09 12:34:49.699096+00	direct_edit	t	t	1
+566	2024-09-09 12:39:29.031929+00	direct_edit	t	f	1
+565	2024-09-09 12:39:21.850678+00	direct_edit	t	f	1
+564	2024-09-09 12:38:45.407038+00	direct_edit	t	f	1
+563	2024-09-09 12:38:38.433731+00	direct_edit	t	f	1
+562	2024-09-09 12:38:21.638096+00	direct_edit	t	f	1
+561	2024-09-09 12:38:04.024341+00	direct_edit	t	t	1
+560	2024-09-09 12:37:55.630884+00	direct_edit	t	t	1
+559	2024-09-09 12:37:40.675049+00	direct_edit	t	t	1
+558	2024-09-09 12:37:36.168929+00	direct_edit	t	t	1
+557	2024-09-09 12:37:31.665195+00	direct_edit	t	t	1
+556	2024-09-09 12:37:27.243943+00	direct_edit	t	t	1
+567	2024-09-09 12:41:56.070963+00	direct_edit	t	f	1
+568	2024-09-09 12:43:44.826086+00	direct_edit	t	f	1
+570	2024-09-09 12:48:58.986939+00	direct_edit	t	t	1
+569	2024-09-09 12:48:26.642027+00	direct_edit	t	t	1
+571	2024-09-09 12:50:13.765199+00	management	t	f	\N
+574	2024-09-09 12:55:50.305978+00	management	t	f	\N
+573	2024-09-09 12:55:14.205586+00	direct_edit	t	t	1
+572	2024-09-09 12:53:09.292181+00	direct_edit	t	t	1
+575	2024-09-09 12:57:13.966329+00	management	t	f	\N
+603	2024-09-09 13:03:45.03202+00	management	t	f	\N
+602	2024-09-09 13:03:30.849157+00	direct_edit	t	f	1
+601	2024-09-09 13:03:26.95121+00	direct_edit	t	f	1
+600	2024-09-09 13:03:24.083947+00	direct_edit	t	f	1
+599	2024-09-09 13:03:17.526609+00	direct_edit	t	f	1
+598	2024-09-09 13:03:13.840004+00	direct_edit	t	f	1
+597	2024-09-09 13:03:10.369874+00	direct_edit	t	f	1
+596	2024-09-09 13:03:01.759687+00	direct_edit	t	f	1
+595	2024-09-09 13:02:58.077408+00	direct_edit	t	f	1
+594	2024-09-09 13:02:52.12882+00	direct_edit	t	f	1
+593	2024-09-09 13:02:46.394023+00	direct_edit	t	f	1
+592	2024-09-09 13:02:27.353622+00	direct_edit	t	f	1
+591	2024-09-09 13:02:17.520558+00	direct_edit	t	f	1
+590	2024-09-09 13:02:13.420799+00	direct_edit	t	f	1
+589	2024-09-09 13:02:08.229664+00	direct_edit	t	f	1
+588	2024-09-09 13:02:04.821244+00	direct_edit	t	f	1
+587	2024-09-09 13:01:48.233024+00	direct_edit	t	f	1
+586	2024-09-09 13:01:37.170637+00	direct_edit	t	f	1
+585	2024-09-09 13:00:52.117656+00	direct_edit	t	f	1
+584	2024-09-09 13:00:46.583968+00	direct_edit	t	f	1
+583	2024-09-09 13:00:28.769765+00	direct_edit	t	f	1
+582	2024-09-09 13:00:23.854871+00	direct_edit	t	f	1
+581	2024-09-09 13:00:19.969116+00	direct_edit	t	f	1
+580	2024-09-09 13:00:14.02975+00	direct_edit	t	f	1
+579	2024-09-09 13:00:06.24147+00	direct_edit	t	f	1
+578	2024-09-09 13:00:03.170837+00	direct_edit	t	f	1
+577	2024-09-09 12:59:37.151395+00	direct_edit	t	t	1
+576	2024-09-09 12:59:10.566704+00	direct_edit	t	t	1
+607	2024-09-09 13:05:17.133838+00	direct_edit	t	f	1
+606	2024-09-09 13:05:05.46058+00	direct_edit	t	f	1
+605	2024-09-09 13:04:59.531447+00	direct_edit	t	f	1
+604	2024-09-09 13:04:53.378149+00	direct_edit	t	f	1
+608	2024-09-09 13:05:34.169905+00	management	t	f	\N
+610	2024-09-09 13:28:14.67968+00	management	t	f	\N
+609	2024-09-09 13:27:34.491531+00	direct_edit	t	f	1
+1454	2024-09-17 10:00:18.739234+00	direct_edit	t	t	1
+631	2024-09-09 13:43:49.356112+00	direct_edit	t	t	1
+630	2024-09-09 13:43:42.194974+00	direct_edit	t	t	1
+629	2024-09-09 13:43:21.295518+00	direct_edit	t	t	1
+628	2024-09-09 13:42:50.17174+00	direct_edit	t	t	1
+627	2024-09-09 13:42:30.731202+00	direct_edit	t	t	1
+626	2024-09-09 13:41:11.864986+00	direct_edit	t	t	1
+658	2024-09-09 13:48:31.172176+00	direct_edit	t	f	1
+657	2024-09-09 13:48:28.714556+00	direct_edit	t	f	1
+656	2024-09-09 13:48:25.84855+00	direct_edit	t	f	1
+655	2024-09-09 13:48:18.679285+00	direct_edit	t	f	1
+654	2024-09-09 13:48:10.284205+00	direct_edit	t	f	1
+653	2024-09-09 13:48:05.782015+00	direct_edit	t	f	1
+652	2024-09-09 13:47:56.153905+00	direct_edit	t	f	1
+651	2024-09-09 13:47:50.212298+00	direct_edit	t	f	1
+650	2024-09-09 13:47:34.43843+00	direct_edit	t	f	1
+649	2024-09-09 13:47:20.14339+00	direct_edit	t	f	1
+648	2024-09-09 13:47:13.346907+00	direct_edit	t	f	1
+647	2024-09-09 13:47:07.408202+00	direct_edit	t	f	1
+646	2024-09-09 13:46:58.400144+00	direct_edit	t	f	1
+645	2024-09-09 13:46:51.431683+00	direct_edit	t	f	1
+644	2024-09-09 13:46:48.153253+00	direct_edit	t	f	1
+643	2024-09-09 13:46:39.763655+00	direct_edit	t	f	1
+642	2024-09-09 13:46:32.998182+00	direct_edit	t	f	1
+641	2024-09-09 13:46:29.722789+00	direct_edit	t	f	1
+640	2024-09-09 13:46:16.817946+00	direct_edit	t	f	1
+639	2024-09-09 13:45:56.332285+00	direct_edit	t	t	1
+638	2024-09-09 13:45:44.250209+00	direct_edit	t	t	1
+637	2024-09-09 13:45:21.929415+00	direct_edit	t	t	1
+636	2024-09-09 13:44:57.574367+00	direct_edit	t	t	1
+635	2024-09-09 13:44:18.23462+00	direct_edit	t	t	1
+634	2024-09-09 13:44:11.476916+00	direct_edit	t	t	1
+633	2024-09-09 13:44:04.664403+00	direct_edit	t	t	1
+632	2024-09-09 13:43:56.727716+00	direct_edit	t	t	1
+625	2024-09-09 13:40:31.92791+00	direct_edit	t	t	1
+624	2024-09-09 13:40:21.068689+00	direct_edit	t	t	1
+623	2024-09-09 13:39:58.948469+00	direct_edit	t	t	1
+622	2024-09-09 13:39:47.480192+00	direct_edit	t	t	1
+621	2024-09-09 13:39:34.578118+00	direct_edit	t	t	1
+620	2024-09-09 13:39:18.194475+00	direct_edit	t	t	1
+619	2024-09-09 13:39:05.495438+00	direct_edit	t	t	1
+618	2024-09-09 13:38:48.313627+00	direct_edit	t	t	1
+617	2024-09-09 13:37:55.685618+00	direct_edit	t	t	1
+616	2024-09-09 13:36:34.581299+00	direct_edit	t	t	1
+615	2024-09-09 13:35:24.539412+00	direct_edit	t	t	1
+614	2024-09-09 13:34:47.876849+00	direct_edit	t	t	1
+613	2024-09-09 13:34:08.14431+00	direct_edit	t	t	1
+612	2024-09-09 13:33:03.473213+00	direct_edit	t	f	1
+611	2024-09-09 13:30:37.800973+00	direct_edit	t	t	1
+659	2024-09-09 13:48:58.707951+00	management	t	f	\N
+666	2024-09-09 13:51:45.35696+00	direct_edit	t	t	1
+665	2024-09-09 13:51:26.310329+00	direct_edit	t	t	1
+664	2024-09-09 13:51:12.999236+00	direct_edit	t	t	1
+663	2024-09-09 13:50:50.062646+00	direct_edit	t	t	1
+662	2024-09-09 13:50:41.254625+00	direct_edit	t	t	1
+661	2024-09-09 13:50:29.57931+00	direct_edit	t	t	1
+660	2024-09-09 13:50:15.448635+00	direct_edit	t	t	1
+687	2024-09-09 14:04:07.322115+00	direct_edit	t	t	1
+686	2024-09-09 14:03:50.324188+00	direct_edit	t	t	1
+685	2024-09-09 14:03:34.759507+00	direct_edit	t	t	1
+684	2024-09-09 14:03:12.643939+00	direct_edit	t	t	1
+683	2024-09-09 14:02:48.474875+00	direct_edit	t	t	1
+682	2024-09-09 14:02:27.173899+00	direct_edit	t	t	1
+681	2024-09-09 14:02:11.200696+00	direct_edit	t	t	1
+680	2024-09-09 14:01:55.635385+00	direct_edit	t	t	1
+679	2024-09-09 14:01:39.455646+00	direct_edit	t	t	1
+678	2024-09-09 14:01:07.508034+00	direct_edit	t	t	1
+677	2024-09-09 13:57:54.995296+00	direct_edit	t	t	1
+676	2024-09-09 13:57:45.776761+00	direct_edit	t	t	1
+675	2024-09-09 13:57:36.968439+00	direct_edit	t	t	1
+674	2024-09-09 13:57:22.839341+00	direct_edit	t	t	1
+673	2024-09-09 13:57:09.730985+00	direct_edit	t	t	1
+672	2024-09-09 13:57:00.310189+00	direct_edit	t	t	1
+671	2024-09-09 13:56:51.299095+00	direct_edit	t	t	1
+670	2024-09-09 13:56:41.468215+00	direct_edit	t	t	1
+669	2024-09-09 13:56:21.400039+00	direct_edit	t	t	1
+668	2024-09-09 13:56:03.375588+00	direct_edit	t	t	1
+667	2024-09-09 13:55:52.113989+00	direct_edit	t	t	1
+698	2024-09-09 14:15:07.441089+00	direct_edit	t	t	1
+697	2024-09-09 14:12:46.122989+00	direct_edit	t	t	1
+696	2024-09-09 14:11:59.222563+00	direct_edit	t	t	1
+695	2024-09-09 14:11:02.910211+00	direct_edit	t	t	1
+694	2024-09-09 14:10:38.946712+00	direct_edit	t	t	1
+693	2024-09-09 14:10:21.53429+00	direct_edit	t	t	1
+692	2024-09-09 14:10:07.249053+00	direct_edit	t	t	1
+691	2024-09-09 14:09:48.966391+00	direct_edit	t	t	1
+690	2024-09-09 14:09:28.28864+00	direct_edit	t	t	1
+689	2024-09-09 14:08:57.571337+00	direct_edit	t	t	1
+688	2024-09-09 14:08:42.821668+00	direct_edit	t	t	1
+1452	2024-09-17 10:00:07.681503+00	direct_edit	t	t	1
+721	2024-09-09 14:42:37.299858+00	direct_edit	t	t	1
+720	2024-09-09 14:42:26.854917+00	direct_edit	t	t	1
+719	2024-09-09 14:42:19.2775+00	direct_edit	t	t	1
+718	2024-09-09 14:41:49.860184+00	direct_edit	t	t	1
+717	2024-09-09 14:41:08.83302+00	direct_edit	t	t	1
+716	2024-09-09 14:40:55.741299+00	direct_edit	t	t	1
+715	2024-09-09 14:39:43.42214+00	direct_edit	t	t	1
+714	2024-09-09 14:39:31.546104+00	direct_edit	t	t	1
+713	2024-09-09 14:39:17.199621+00	direct_edit	t	f	1
+712	2024-09-09 14:38:26.830121+00	direct_edit	t	t	1
+711	2024-09-09 14:37:35.419623+00	direct_edit	t	t	1
+741	2024-09-09 14:46:14.812377+00	direct_edit	t	f	1
+740	2024-09-09 14:46:08.05121+00	direct_edit	t	f	1
+739	2024-09-09 14:46:01.289731+00	direct_edit	t	f	1
+738	2024-09-09 14:45:57.809232+00	direct_edit	t	f	1
+737	2024-09-09 14:45:53.508681+00	direct_edit	t	f	1
+736	2024-09-09 14:45:48.591985+00	direct_edit	t	f	1
+735	2024-09-09 14:45:37.157912+00	direct_edit	t	f	1
+734	2024-09-09 14:45:34.050797+00	direct_edit	t	f	1
+733	2024-09-09 14:45:20.326512+00	direct_edit	t	f	1
+732	2024-09-09 14:45:18.076862+00	direct_edit	t	f	1
+731	2024-09-09 14:45:14.553235+00	direct_edit	t	f	1
+730	2024-09-09 14:45:13.159283+00	direct_edit	t	f	1
+729	2024-09-09 14:45:00.25725+00	direct_edit	t	f	1
+728	2024-09-09 14:44:10.693149+00	direct_edit	t	t	1
+727	2024-09-09 14:43:36.692517+00	direct_edit	t	t	1
+726	2024-09-09 14:43:24.199819+00	direct_edit	t	t	1
+725	2024-09-09 14:43:16.005348+00	direct_edit	t	t	1
+724	2024-09-09 14:43:06.176757+00	direct_edit	t	t	1
+723	2024-09-09 14:42:55.730699+00	direct_edit	t	t	1
+722	2024-09-09 14:42:47.129569+00	direct_edit	t	t	1
+710	2024-09-09 14:37:17.631584+00	direct_edit	t	t	1
+709	2024-09-09 14:33:37.495966+00	direct_edit	t	t	1
+708	2024-09-09 14:32:03.642575+00	direct_edit	t	f	1
+707	2024-09-09 14:31:25.169783+00	direct_edit	t	t	1
+706	2024-09-09 14:31:15.346592+00	direct_edit	t	t	1
+705	2024-09-09 14:23:56.448109+00	direct_edit	t	t	1
+704	2024-09-09 14:23:46.206295+00	direct_edit	t	t	1
+703	2024-09-09 14:23:36.585252+00	direct_edit	t	t	1
+702	2024-09-09 14:22:52.557659+00	direct_edit	t	t	1
+701	2024-09-09 14:22:43.741771+00	direct_edit	t	t	1
+700	2024-09-09 14:22:27.762349+00	direct_edit	t	t	1
+699	2024-09-09 14:21:27.152056+00	direct_edit	t	t	1
+742	2024-09-09 14:46:38.004481+00	management	t	f	\N
+759	2024-09-09 14:53:24.341781+00	management	t	f	\N
+758	2024-09-09 14:52:31.870219+00	direct_edit	t	t	1
+757	2024-09-09 14:51:33.679277+00	direct_edit	t	t	1
+756	2024-09-09 14:51:26.514627+00	direct_edit	t	t	1
+755	2024-09-09 14:51:19.962915+00	direct_edit	t	t	1
+754	2024-09-09 14:51:11.9709+00	direct_edit	t	t	1
+753	2024-09-09 14:51:05.416861+00	direct_edit	t	t	1
+752	2024-09-09 14:50:53.135543+00	direct_edit	t	t	1
+751	2024-09-09 14:50:27.528711+00	direct_edit	t	t	1
+750	2024-09-09 14:50:19.95056+00	direct_edit	t	t	1
+749	2024-09-09 14:50:10.120533+00	direct_edit	t	t	1
+748	2024-09-09 14:49:59.67579+00	direct_edit	t	t	1
+747	2024-09-09 14:49:52.199725+00	direct_edit	t	t	1
+746	2024-09-09 14:49:44.117897+00	direct_edit	t	t	1
+745	2024-09-09 14:49:27.1135+00	direct_edit	t	t	1
+744	2024-09-09 14:49:21.181014+00	direct_edit	t	t	1
+743	2024-09-09 14:49:06.449208+00	direct_edit	t	t	1
+773	2024-09-09 14:57:05.611561+00	management	t	f	\N
+772	2024-09-09 14:56:56.867307+00	direct_edit	t	f	1
+771	2024-09-09 14:56:51.544724+00	direct_edit	t	f	1
+770	2024-09-09 14:56:39.467066+00	direct_edit	t	f	1
+769	2024-09-09 14:56:28.609327+00	direct_edit	t	f	1
+768	2024-09-09 14:56:15.699736+00	direct_edit	t	f	1
+767	2024-09-09 14:56:02.795991+00	direct_edit	t	f	1
+766	2024-09-09 14:55:41.499774+00	direct_edit	t	f	1
+765	2024-09-09 14:55:33.514474+00	direct_edit	t	f	1
+764	2024-09-09 14:55:26.756891+00	direct_edit	t	f	1
+763	2024-09-09 14:55:17.538542+00	direct_edit	t	f	1
+762	2024-09-09 14:55:10.371135+00	direct_edit	t	f	1
+761	2024-09-09 14:54:47.225281+00	direct_edit	t	f	1
+760	2024-09-09 14:54:38.651452+00	direct_edit	t	t	1
+774	2024-09-09 14:57:18.623603+00	management	t	f	\N
+794	2024-09-09 15:03:16.641422+00	management	t	f	\N
+793	2024-09-09 15:03:00.191054+00	direct_edit	t	f	1
+792	2024-09-09 15:02:56.912913+00	direct_edit	t	f	1
+791	2024-09-09 15:02:54.055947+00	direct_edit	t	f	1
+790	2024-09-09 15:02:50.162101+00	direct_edit	t	f	1
+789	2024-09-09 15:02:47.493644+00	direct_edit	t	f	1
+788	2024-09-09 15:02:44.007636+00	direct_edit	t	f	1
+787	2024-09-09 15:02:37.050894+00	direct_edit	t	f	1
+786	2024-09-09 15:02:34.186485+00	direct_edit	t	f	1
+785	2024-09-09 15:02:31.519509+00	direct_edit	t	f	1
+784	2024-09-09 15:02:21.070813+00	direct_edit	t	f	1
+783	2024-09-09 15:02:10.421794+00	direct_edit	t	f	1
+782	2024-09-09 15:01:59.773053+00	direct_edit	t	f	1
+781	2024-09-09 15:01:56.702011+00	direct_edit	t	f	1
+780	2024-09-09 15:01:53.419768+00	direct_edit	t	f	1
+779	2024-09-09 15:01:32.740429+00	direct_edit	t	f	1
+778	2024-09-09 15:01:28.228709+00	direct_edit	t	f	1
+777	2024-09-09 15:01:12.25606+00	direct_edit	t	f	1
+776	2024-09-09 15:01:10.006245+00	direct_edit	t	f	1
+775	2024-09-09 14:59:32.547784+00	direct_edit	t	t	1
+797	2024-09-09 15:06:40.045046+00	management	t	f	\N
+796	2024-09-09 15:06:33.382507+00	direct_edit	t	t	1
+795	2024-09-09 15:06:15.801827+00	direct_edit	t	t	1
+799	2024-09-09 15:10:57.869151+00	management	t	f	\N
+798	2024-09-09 15:10:32.129171+00	direct_edit	t	t	1
+801	2024-09-09 15:13:47.635457+00	management	t	f	\N
+800	2024-09-09 15:13:35.720719+00	direct_edit	t	t	1
+1455	2024-09-17 10:03:27.308168+00	direct_edit	t	f	1
+819	2024-09-09 15:22:02.165001+00	direct_edit	t	t	1
+818	2024-09-09 15:21:37.179556+00	direct_edit	t	t	1
+817	2024-09-09 15:21:27.967841+00	direct_edit	t	t	1
+816	2024-09-09 15:21:20.184142+00	direct_edit	t	t	1
+815	2024-09-09 15:21:05.846867+00	direct_edit	t	t	1
+814	2024-09-09 15:21:00.110493+00	direct_edit	t	t	1
+823	2024-09-09 15:23:38.76088+00	management	t	f	\N
+822	2024-09-09 15:23:21.837302+00	direct_edit	t	t	1
+821	2024-09-09 15:22:39.030878+00	direct_edit	t	t	1
+820	2024-09-09 15:22:21.006923+00	direct_edit	t	t	1
+813	2024-09-09 15:20:32.667788+00	direct_edit	t	t	1
+812	2024-09-09 15:20:07.073381+00	direct_edit	t	t	1
+811	2024-09-09 15:19:58.471777+00	direct_edit	t	t	1
+810	2024-09-09 15:19:37.187125+00	direct_edit	t	t	1
+809	2024-09-09 15:18:31.422418+00	direct_edit	t	t	1
+808	2024-09-09 15:18:18.376823+00	direct_edit	t	t	1
+807	2024-09-09 15:17:56.400423+00	direct_edit	t	t	1
+806	2024-09-09 15:17:35.936931+00	direct_edit	t	t	1
+805	2024-09-09 15:17:15.651589+00	direct_edit	t	t	1
+804	2024-09-09 15:16:59.057677+00	direct_edit	t	t	1
+803	2024-09-09 15:16:48.201833+00	direct_edit	t	t	1
+802	2024-09-09 15:16:27.139051+00	direct_edit	t	t	1
+826	2024-09-09 15:25:05.571358+00	management	t	f	\N
+825	2024-09-09 15:24:31.987392+00	direct_edit	t	t	1
+824	2024-09-09 15:24:24.916009+00	direct_edit	t	t	1
+827	2024-09-09 15:25:18.240423+00	management	t	f	\N
+834	2024-09-09 15:27:00.815678+00	management	t	f	\N
+833	2024-09-09 15:26:42.55383+00	direct_edit	t	f	1
+832	2024-09-09 15:26:37.844086+00	direct_edit	t	f	1
+831	2024-09-09 15:26:32.307001+00	direct_edit	t	f	1
+830	2024-09-09 15:26:28.825505+00	direct_edit	t	f	1
+829	2024-09-09 15:26:13.258574+00	direct_edit	t	f	1
+828	2024-09-09 15:26:11.417793+00	direct_edit	t	f	1
+838	2024-09-09 15:29:18.531931+00	direct_edit	t	t	1
+837	2024-09-09 15:29:07.751553+00	direct_edit	t	t	1
+836	2024-09-09 15:28:47.680282+00	direct_edit	t	t	1
+835	2024-09-09 15:28:31.910177+00	direct_edit	t	t	1
+843	2024-09-09 15:32:04.506854+00	direct_edit	t	f	1
+842	2024-09-09 15:31:23.331322+00	direct_edit	t	t	1
+841	2024-09-09 15:31:14.325872+00	direct_edit	t	t	1
+840	2024-09-09 15:30:39.091431+00	direct_edit	t	t	1
+839	2024-09-09 15:30:23.319439+00	direct_edit	t	t	1
+845	2024-09-09 15:35:32.372085+00	direct_edit	t	t	1
+844	2024-09-09 15:34:35.847373+00	direct_edit	t	t	1
+1456	2024-09-17 10:05:11.639195+00	direct_edit	t	t	1
+901	2024-09-09 15:48:00.104842+00	direct_edit	t	t	1
+900	2024-09-09 15:47:53.961517+00	direct_edit	t	t	1
+899	2024-09-09 15:47:34.720627+00	direct_edit	t	t	1
+898	2024-09-09 15:47:11.567502+00	direct_edit	t	t	1
+897	2024-09-09 15:47:05.015101+00	direct_edit	t	t	1
+896	2024-09-09 15:46:58.051044+00	direct_edit	t	t	1
+895	2024-09-09 15:46:39.419062+00	direct_edit	t	t	1
+894	2024-09-09 15:46:28.153253+00	direct_edit	t	t	1
+893	2024-09-09 15:46:20.782602+00	direct_edit	t	t	1
+892	2024-09-09 15:46:07.205055+00	direct_edit	t	t	1
+891	2024-09-09 15:45:37.158161+00	direct_edit	t	t	1
+890	2024-09-09 15:45:12.783557+00	direct_edit	t	t	1
+889	2024-09-09 15:45:05.613235+00	direct_edit	t	t	1
+888	2024-09-09 15:44:56.398826+00	direct_edit	t	t	1
+887	2024-09-09 15:43:51.895105+00	direct_edit	t	f	1
+886	2024-09-09 15:43:49.0265+00	direct_edit	t	f	1
+885	2024-09-09 15:43:33.252773+00	direct_edit	t	f	1
+884	2024-09-09 15:43:29.770647+00	direct_edit	t	f	1
+883	2024-09-09 15:43:27.5188+00	direct_edit	t	f	1
+882	2024-09-09 15:43:06.423156+00	direct_edit	t	f	1
+881	2024-09-09 15:43:04.578857+00	direct_edit	t	f	1
+880	2024-09-09 15:42:54.749394+00	direct_edit	t	f	1
+879	2024-09-09 15:42:52.906128+00	direct_edit	t	f	1
+878	2024-09-09 15:42:48.809602+00	direct_edit	t	f	1
+877	2024-09-09 15:42:46.352972+00	direct_edit	t	f	1
+876	2024-09-09 15:42:43.081229+00	direct_edit	t	f	1
+875	2024-09-09 15:42:17.68852+00	direct_edit	t	f	1
+874	2024-09-09 15:42:16.054336+00	direct_edit	t	f	1
+873	2024-09-09 15:42:14.412413+00	direct_edit	t	f	1
+872	2024-09-09 15:41:58.843281+00	direct_edit	t	f	1
+871	2024-09-09 15:41:55.769955+00	direct_edit	t	f	1
+870	2024-09-09 15:41:52.284859+00	direct_edit	t	f	1
+869	2024-09-09 15:41:49.008141+00	direct_edit	t	f	1
+868	2024-09-09 15:41:42.457152+00	direct_edit	t	f	1
+867	2024-09-09 15:41:36.513765+00	direct_edit	t	f	1
+866	2024-09-09 15:41:31.392503+00	direct_edit	t	f	1
+865	2024-09-09 15:41:24.428782+00	direct_edit	t	f	1
+864	2024-09-09 15:41:22.794299+00	direct_edit	t	f	1
+863	2024-09-09 15:41:21.567533+00	direct_edit	t	f	1
+862	2024-09-09 15:41:19.929128+00	direct_edit	t	f	1
+861	2024-09-09 15:41:12.144284+00	direct_edit	t	f	1
+860	2024-09-09 15:40:59.239368+00	direct_edit	t	f	1
+859	2024-09-09 15:40:52.685648+00	direct_edit	t	f	1
+858	2024-09-09 15:40:36.100573+00	direct_edit	t	f	1
+857	2024-09-09 15:40:33.646623+00	direct_edit	t	f	1
+856	2024-09-09 15:40:29.750576+00	direct_edit	t	f	1
+855	2024-09-09 15:40:27.905151+00	direct_edit	t	f	1
+854	2024-09-09 15:40:16.844008+00	direct_edit	t	f	1
+853	2024-09-09 15:40:10.088577+00	direct_edit	t	f	1
+852	2024-09-09 15:40:03.742177+00	direct_edit	t	f	1
+851	2024-09-09 15:39:56.779731+00	direct_edit	t	f	1
+850	2024-09-09 15:39:54.729627+00	direct_edit	t	f	1
+849	2024-09-09 15:39:41.825332+00	direct_edit	t	f	1
+848	2024-09-09 15:39:32.931356+00	direct_edit	t	f	1
+847	2024-09-09 15:39:25.442567+00	direct_edit	t	f	1
+846	2024-09-09 15:39:17.075826+00	direct_edit	t	t	1
+926	2024-09-09 15:53:31.791144+00	direct_edit	t	f	1
+925	2024-09-09 15:52:55.852348+00	direct_edit	t	f	1
+924	2024-09-09 15:52:52.779984+00	direct_edit	t	f	1
+923	2024-09-09 15:52:46.220708+00	direct_edit	t	t	1
+922	2024-09-09 15:52:16.741247+00	direct_edit	t	f	1
+921	2024-09-09 15:52:12.633944+00	direct_edit	t	f	1
+920	2024-09-09 15:52:07.108412+00	direct_edit	t	f	1
+919	2024-09-09 15:52:05.060613+00	direct_edit	t	f	1
+918	2024-09-09 15:52:00.146159+00	direct_edit	t	f	1
+917	2024-09-09 15:51:49.905508+00	direct_edit	t	f	1
+916	2024-09-09 15:51:44.786188+00	direct_edit	t	f	1
+915	2024-09-09 15:51:40.070199+00	direct_edit	t	f	1
+914	2024-09-09 15:51:28.805581+00	direct_edit	t	f	1
+913	2024-09-09 15:51:24.094114+00	direct_edit	t	f	1
+912	2024-09-09 15:51:17.336304+00	direct_edit	t	f	1
+911	2024-09-09 15:51:08.537834+00	direct_edit	t	f	1
+910	2024-09-09 15:51:05.051844+00	direct_edit	t	f	1
+909	2024-09-09 15:51:01.335741+00	direct_edit	t	f	1
+908	2024-09-09 15:50:57.679261+00	direct_edit	t	f	1
+907	2024-09-09 15:50:54.607382+00	direct_edit	t	f	1
+906	2024-09-09 15:50:49.494613+00	direct_edit	t	f	1
+905	2024-09-09 15:50:39.659019+00	direct_edit	t	f	1
+904	2024-09-09 15:50:32.484294+00	direct_edit	t	f	1
+903	2024-09-09 15:50:28.593042+00	direct_edit	t	f	1
+902	2024-09-09 15:50:21.840726+00	direct_edit	t	f	1
+931	2024-09-09 15:58:46.883933+00	direct_edit	t	f	1
+930	2024-09-09 15:58:20.877154+00	direct_edit	t	f	1
+929	2024-09-09 15:58:18.622145+00	direct_edit	t	f	1
+928	2024-09-09 15:58:11.04266+00	direct_edit	t	f	1
+927	2024-09-09 15:58:04.89416+00	direct_edit	t	f	1
+956	2024-09-09 16:03:22.546346+00	direct_edit	t	f	1
+955	2024-09-09 16:03:17.836562+00	direct_edit	t	f	1
+954	2024-09-09 16:03:07.595391+00	direct_edit	t	f	1
+953	2024-09-09 16:02:57.559898+00	direct_edit	t	f	1
+952	2024-09-09 16:02:44.461183+00	direct_edit	t	f	1
+951	2024-09-09 16:02:27.666751+00	direct_edit	t	f	1
+950	2024-09-09 16:02:15.780412+00	direct_edit	t	f	1
+949	2024-09-09 16:02:13.938969+00	direct_edit	t	f	1
+948	2024-09-09 16:02:08.614082+00	direct_edit	t	f	1
+947	2024-09-09 16:02:07.178099+00	direct_edit	t	f	1
+946	2024-09-09 16:02:05.745597+00	direct_edit	t	f	1
+945	2024-09-09 16:01:57.141895+00	direct_edit	t	f	1
+944	2024-09-09 16:01:52.024287+00	direct_edit	t	f	1
+943	2024-09-09 16:01:46.493704+00	direct_edit	t	f	1
+942	2024-09-09 16:01:41.373295+00	direct_edit	t	f	1
+941	2024-09-09 16:01:39.426621+00	direct_edit	t	f	1
+940	2024-09-09 16:01:33.183144+00	direct_edit	t	f	1
+939	2024-09-09 16:01:24.378937+00	direct_edit	t	f	1
+938	2024-09-09 16:01:09.226872+00	direct_edit	t	f	1
+937	2024-09-09 16:00:57.75291+00	direct_edit	t	f	1
+936	2024-09-09 16:00:54.680543+00	direct_edit	t	f	1
+935	2024-09-09 16:00:52.226405+00	direct_edit	t	f	1
+934	2024-09-09 16:00:43.004831+00	direct_edit	t	f	1
+933	2024-09-09 16:00:30.306412+00	direct_edit	t	f	1
+932	2024-09-09 16:00:23.136976+00	direct_edit	t	f	1
+959	2024-09-09 16:06:00.660218+00	direct_edit	t	f	1
+958	2024-09-09 16:05:57.593639+00	direct_edit	t	f	1
+957	2024-09-09 16:05:53.901182+00	direct_edit	t	f	1
+961	2024-09-09 16:07:16.455108+00	direct_edit	t	f	1
+960	2024-09-09 16:07:08.651333+00	direct_edit	t	f	1
+963	2024-09-09 16:10:55.58048+00	direct_edit	t	f	1
+962	2024-09-09 16:10:03.135512+00	direct_edit	t	t	1
+969	2024-09-09 16:11:37.356612+00	direct_edit	t	f	1
+968	2024-09-09 16:11:33.467715+00	direct_edit	t	f	1
+967	2024-09-09 16:11:31.418572+00	direct_edit	t	f	1
+966	2024-09-09 16:11:27.736257+00	direct_edit	t	f	1
+965	2024-09-09 16:11:23.83446+00	direct_edit	t	f	1
+964	2024-09-09 16:11:22.399638+00	direct_edit	t	f	1
+977	2024-09-09 16:16:14.656205+00	direct_edit	t	f	1
+976	2024-09-09 16:15:59.502132+00	direct_edit	t	f	1
+975	2024-09-09 16:15:48.938214+00	direct_edit	t	f	1
+974	2024-09-09 16:15:35.119841+00	direct_edit	t	t	1
+973	2024-09-09 16:14:39.017091+00	direct_edit	t	f	1
+972	2024-09-09 16:14:36.152595+00	direct_edit	t	f	1
+971	2024-09-09 16:14:32.053479+00	direct_edit	t	f	1
+970	2024-09-09 16:14:27.543746+00	direct_edit	t	f	1
+1457	2024-09-17 10:05:30.041206+00	direct_edit	t	t	1
+983	2024-09-10 06:22:36.888074+00	direct_edit	t	t	1
+982	2024-09-10 06:22:21.118129+00	direct_edit	t	t	1
+981	2024-09-10 06:22:11.081416+00	direct_edit	t	t	1
+980	2024-09-10 06:21:54.901983+00	direct_edit	t	t	1
+979	2024-09-10 06:21:18.468894+00	direct_edit	t	t	1
+978	2024-09-10 06:18:29.074162+00	direct_edit	t	t	1
+984	2024-09-10 06:33:32.724259+00	management	t	f	\N
+989	2024-09-10 06:37:19.818788+00	direct_edit	t	t	1
+988	2024-09-10 06:36:20.404931+00	direct_edit	t	t	1
+987	2024-09-10 06:35:51.339245+00	direct_edit	t	t	1
+986	2024-09-10 06:34:15.679963+00	direct_edit	t	t	1
+985	2024-09-10 06:34:05.038753+00	direct_edit	t	t	1
+990	2024-09-10 06:38:35.260487+00	management	t	f	\N
+991	2024-09-10 06:42:04.397867+00	management	t	f	\N
+994	2024-09-10 06:52:59.081015+00	management	t	f	\N
+993	2024-09-10 06:52:46.938868+00	direct_edit	t	f	1
+992	2024-09-10 06:50:18.256989+00	direct_edit	t	f	1
+1000	2024-09-10 07:01:49.312009+00	management	t	f	\N
+999	2024-09-10 07:00:45.581379+00	direct_edit	t	t	1
+998	2024-09-10 07:00:11.590715+00	direct_edit	t	t	1
+997	2024-09-10 06:58:58.476081+00	direct_edit	t	t	1
+996	2024-09-10 06:57:30.822485+00	direct_edit	t	t	1
+995	2024-09-10 06:55:38.36628+00	direct_edit	t	t	1
+1001	2024-09-10 07:01:58.836854+00	management	t	f	\N
+1010	2024-09-10 07:08:13.678342+00	direct_edit	t	t	1
+1009	2024-09-10 07:07:58.119787+00	direct_edit	t	t	1
+1008	2024-09-10 07:07:41.11907+00	direct_edit	t	t	1
+1007	2024-09-10 07:07:33.207083+00	direct_edit	t	f	1
+1006	2024-09-10 07:07:25.771546+00	direct_edit	t	t	1
+1005	2024-09-10 07:07:09.579729+00	direct_edit	t	t	1
+1004	2024-09-10 07:07:03.638362+00	direct_edit	t	t	1
+1003	2024-09-10 07:06:36.592162+00	direct_edit	t	f	1
+1002	2024-09-10 07:06:26.145492+00	direct_edit	t	f	1
+1011	2024-09-10 07:08:41.054164+00	management	t	f	\N
+1012	2024-09-10 07:10:25.886125+00	management	t	f	\N
+1013	2024-09-10 07:10:35.84252+00	management	t	f	\N
+1458	2024-09-24 09:20:31.075516+00	management	t	f	\N
+1071	2024-09-10 07:31:44.779065+00	direct_edit	t	f	1
+1070	2024-09-10 07:31:40.68586+00	direct_edit	t	f	1
+1069	2024-09-10 07:31:21.032366+00	direct_edit	t	f	1
+1068	2024-09-10 07:31:17.138664+00	direct_edit	t	f	1
+1067	2024-09-10 07:31:04.22757+00	direct_edit	t	t	1
+1066	2024-09-10 07:30:56.237034+00	direct_edit	t	f	1
+1065	2024-09-10 07:30:34.124262+00	direct_edit	t	f	1
+1064	2024-09-10 07:30:26.953416+00	direct_edit	t	f	1
+1063	2024-09-10 07:30:17.121261+00	direct_edit	t	f	1
+1062	2024-09-10 07:30:09.746568+00	direct_edit	t	f	1
+1061	2024-09-10 07:29:57.663086+00	direct_edit	t	f	1
+1060	2024-09-10 07:29:55.818907+00	direct_edit	t	f	1
+1059	2024-09-10 07:29:40.664954+00	direct_edit	t	f	1
+1058	2024-09-10 07:29:38.412682+00	direct_edit	t	f	1
+1057	2024-09-10 07:29:30.424139+00	direct_edit	t	f	1
+1056	2024-09-10 07:29:23.46604+00	direct_edit	t	f	1
+1055	2024-09-10 07:28:58.68489+00	direct_edit	t	f	1
+1054	2024-09-10 07:28:15.47345+00	direct_edit	t	f	1
+1053	2024-09-10 07:27:50.489936+00	direct_edit	t	f	1
+1052	2024-09-10 07:27:36.763103+00	direct_edit	t	f	1
+1051	2024-09-10 07:27:08.700572+00	direct_edit	t	f	1
+1050	2024-09-10 07:27:03.17155+00	direct_edit	t	f	1
+1049	2024-09-10 07:26:41.671668+00	direct_edit	t	f	1
+1048	2024-09-10 07:26:24.094783+00	direct_edit	t	f	1
+1047	2024-09-10 07:26:05.018583+00	direct_edit	t	f	1
+1046	2024-09-10 07:25:50.466543+00	direct_edit	t	f	1
+1045	2024-09-10 07:25:17.916165+00	direct_edit	t	f	1
+1081	2024-09-10 07:33:44.595645+00	direct_edit	t	f	1
+1080	2024-09-10 07:33:33.531432+00	direct_edit	t	f	1
+1079	2024-09-10 07:33:20.831094+00	direct_edit	t	f	1
+1078	2024-09-10 07:33:17.144203+00	direct_edit	t	f	1
+1077	2024-09-10 07:33:05.270051+00	direct_edit	t	f	1
+1076	2024-09-10 07:32:55.03399+00	direct_edit	t	f	1
+1075	2024-09-10 07:32:44.785066+00	direct_edit	t	f	1
+1074	2024-09-10 07:32:33.119238+00	direct_edit	t	f	1
+1073	2024-09-10 07:32:26.361774+00	direct_edit	t	f	1
+1072	2024-09-10 07:32:22.469286+00	direct_edit	t	f	1
+1044	2024-09-10 07:25:11.968955+00	direct_edit	t	f	1
+1043	2024-09-10 07:25:09.919392+00	direct_edit	t	f	1
+1042	2024-09-10 07:24:52.717905+00	direct_edit	t	f	1
+1041	2024-09-10 07:24:49.435088+00	direct_edit	t	f	1
+1040	2024-09-10 07:24:46.773264+00	direct_edit	t	f	1
+1039	2024-09-10 07:24:23.845091+00	direct_edit	t	f	1
+1038	2024-09-10 07:24:20.560327+00	direct_edit	t	f	1
+1037	2024-09-10 07:24:18.92284+00	direct_edit	t	f	1
+1036	2024-09-10 07:23:50.864879+00	direct_edit	t	f	1
+1035	2024-09-10 07:23:44.112658+00	direct_edit	t	f	1
+1034	2024-09-10 07:23:41.857947+00	direct_edit	t	f	1
+1033	2024-09-10 07:23:39.189714+00	direct_edit	t	f	1
+1032	2024-09-10 07:23:36.319899+00	direct_edit	t	f	1
+1031	2024-09-10 07:23:10.721979+00	direct_edit	t	t	1
+1030	2024-09-10 07:23:01.086375+00	direct_edit	t	t	1
+1029	2024-09-10 07:22:03.150649+00	direct_edit	t	t	1
+1028	2024-09-10 07:21:40.824725+00	direct_edit	t	t	1
+1027	2024-09-10 07:20:56.365353+00	direct_edit	t	t	1
+1026	2024-09-10 07:20:42.296313+00	direct_edit	t	t	1
+1025	2024-09-10 07:19:49.695157+00	direct_edit	t	t	1
+1024	2024-09-10 07:19:25.260586+00	direct_edit	t	t	1
+1023	2024-09-10 07:19:13.366464+00	direct_edit	t	t	1
+1022	2024-09-10 07:17:59.858424+00	direct_edit	t	t	1
+1021	2024-09-10 07:17:22.980022+00	direct_edit	t	t	1
+1020	2024-09-10 07:16:23.387289+00	direct_edit	t	t	1
+1019	2024-09-10 07:15:02.46272+00	direct_edit	t	t	1
+1018	2024-09-10 07:14:53.455803+00	direct_edit	t	t	1
+1017	2024-09-10 07:14:30.148124+00	direct_edit	t	t	1
+1016	2024-09-10 07:13:29.931682+00	direct_edit	t	t	1
+1015	2024-09-10 07:11:40.329937+00	direct_edit	t	f	1
+1014	2024-09-10 07:11:33.776659+00	direct_edit	t	f	1
+1082	2024-09-10 07:34:15.759685+00	management	t	f	\N
+1105	2024-09-10 07:38:24.963291+00	direct_edit	t	f	1
+1104	2024-09-10 07:38:21.27844+00	direct_edit	t	f	1
+1103	2024-09-10 07:38:18.818351+00	direct_edit	t	f	1
+1102	2024-09-10 07:38:16.157492+00	direct_edit	t	f	1
+1101	2024-09-10 07:38:12.263816+00	direct_edit	t	f	1
+1100	2024-09-10 07:38:07.560253+00	direct_edit	t	f	1
+1099	2024-09-10 07:38:01.619635+00	direct_edit	t	f	1
+1098	2024-09-10 07:37:57.925508+00	direct_edit	t	f	1
+1097	2024-09-10 07:37:55.678166+00	direct_edit	t	f	1
+1096	2024-09-10 07:37:50.968628+00	direct_edit	t	f	1
+1095	2024-09-10 07:37:46.444113+00	direct_edit	t	f	1
+1094	2024-09-10 07:37:34.173938+00	direct_edit	t	f	1
+1093	2024-09-10 07:37:26.796477+00	direct_edit	t	f	1
+1092	2024-09-10 07:37:18.814936+00	direct_edit	t	f	1
+1091	2024-09-10 07:37:11.847109+00	direct_edit	t	f	1
+1090	2024-09-10 07:36:38.88559+00	direct_edit	t	f	1
+1089	2024-09-10 07:36:35.349165+00	direct_edit	t	f	1
+1088	2024-09-10 07:36:28.637432+00	direct_edit	t	f	1
+1087	2024-09-10 07:36:23.315367+00	direct_edit	t	f	1
+1086	2024-09-10 07:36:18.198093+00	direct_edit	t	f	1
+1085	2024-09-10 07:36:13.895611+00	direct_edit	t	f	1
+1084	2024-09-10 07:36:10.619955+00	direct_edit	t	f	1
+1083	2024-09-10 07:35:59.966899+00	direct_edit	t	f	1
+1106	2024-09-10 07:38:44.865336+00	management	t	f	\N
+1117	2024-09-10 07:40:17.832002+00	management	t	f	\N
+1116	2024-09-10 07:40:02.665381+00	direct_edit	t	f	1
+1115	2024-09-10 07:39:59.798852+00	direct_edit	t	f	1
+1114	2024-09-10 07:39:55.900552+00	direct_edit	t	f	1
+1113	2024-09-10 07:39:53.240895+00	direct_edit	t	f	1
+1112	2024-09-10 07:39:50.790082+00	direct_edit	t	f	1
+1111	2024-09-10 07:39:48.326713+00	direct_edit	t	f	1
+1110	2024-09-10 07:39:41.155381+00	direct_edit	t	f	1
+1109	2024-09-10 07:39:38.287972+00	direct_edit	t	f	1
+1108	2024-09-10 07:39:34.601079+00	direct_edit	t	f	1
+1107	2024-09-10 07:39:27.643685+00	direct_edit	t	f	1
+1122	2024-09-10 07:43:09.431356+00	direct_edit	t	t	1
+1121	2024-09-10 07:43:02.673132+00	direct_edit	t	f	1
+1120	2024-09-10 07:42:58.371451+00	direct_edit	t	f	1
+1119	2024-09-10 07:42:47.312706+00	direct_edit	t	f	1
+1118	2024-09-10 07:42:37.892976+00	direct_edit	t	t	1
+1123	2024-09-10 07:43:47.367298+00	management	t	f	\N
+1125	2024-09-10 08:51:41.065157+00	direct_edit	t	t	1
+1124	2024-09-10 08:51:26.319809+00	direct_edit	t	t	1
+1126	2024-09-10 08:52:45.444994+00	management	t	f	\N
+1139	2024-09-10 09:03:25.386854+00	direct_edit	t	f	1
+1138	2024-09-10 09:03:20.265732+00	direct_edit	t	f	1
+1137	2024-09-10 09:03:11.255069+00	direct_edit	t	f	1
+1136	2024-09-10 09:03:02.247125+00	direct_edit	t	f	1
+1135	2024-09-10 09:02:55.688952+00	direct_edit	t	f	1
+1134	2024-09-10 09:02:39.093267+00	direct_edit	t	t	1
+1133	2024-09-10 09:02:21.072475+00	direct_edit	t	t	1
+1132	2024-09-10 09:02:07.355806+00	direct_edit	t	t	1
+1131	2024-09-10 09:01:51.406459+00	direct_edit	t	t	1
+1130	2024-09-10 08:59:34.999033+00	direct_edit	t	t	1
+1129	2024-09-10 08:59:04.697292+00	direct_edit	t	t	1
+1128	2024-09-10 08:58:29.055523+00	direct_edit	t	t	1
+1127	2024-09-10 08:55:16.552757+00	direct_edit	t	t	1
+1459	2024-09-24 09:23:49.369172+00	management	t	f	\N
+1168	2024-09-10 09:16:52.598778+00	management	t	f	\N
+1167	2024-09-10 09:16:31.015353+00	direct_edit	t	t	1
+1166	2024-09-10 09:16:19.541274+00	direct_edit	t	t	1
+1165	2024-09-10 09:15:54.964396+00	direct_edit	t	t	1
+1164	2024-09-10 09:15:42.471133+00	direct_edit	t	t	1
+1163	2024-09-10 09:15:25.883527+00	direct_edit	t	t	1
+1162	2024-09-10 09:15:13.185646+00	direct_edit	t	t	1
+1161	2024-09-10 09:14:41.031198+00	direct_edit	t	t	1
+1160	2024-09-10 09:14:27.927123+00	direct_edit	t	t	1
+1159	2024-09-10 09:14:06.008888+00	direct_edit	t	t	1
+1158	2024-09-10 09:13:51.468061+00	direct_edit	t	t	1
+1157	2024-09-10 09:10:20.722623+00	direct_edit	t	t	1
+1156	2024-09-10 09:09:55.737451+00	direct_edit	t	t	1
+1155	2024-09-10 09:09:07.642834+00	direct_edit	t	t	1
+1154	2024-09-10 09:04:49.776333+00	direct_edit	t	f	1
+1153	2024-09-10 09:04:46.905732+00	direct_edit	t	t	1
+1152	2024-09-10 09:04:38.296838+00	direct_edit	t	f	1
+1151	2024-09-10 09:04:37.078347+00	direct_edit	t	f	1
+1150	2024-09-10 09:04:34.820855+00	direct_edit	t	f	1
+1149	2024-09-10 09:04:32.169107+00	direct_edit	t	f	1
+1148	2024-09-10 09:04:29.093588+00	direct_edit	t	f	1
+1147	2024-09-10 09:04:25.603541+00	direct_edit	t	f	1
+1146	2024-09-10 09:04:05.750208+00	direct_edit	t	f	1
+1145	2024-09-10 09:04:01.84966+00	direct_edit	t	f	1
+1144	2024-09-10 09:04:00.209123+00	direct_edit	t	f	1
+1143	2024-09-10 09:03:57.958611+00	direct_edit	t	f	1
+1142	2024-09-10 09:03:55.90805+00	direct_edit	t	f	1
+1141	2024-09-10 09:03:53.508422+00	direct_edit	t	f	1
+1140	2024-09-10 09:03:48.938429+00	direct_edit	t	f	1
+1170	2024-09-10 09:20:52.348011+00	direct_edit	t	t	1
+1169	2024-09-10 09:20:32.712751+00	direct_edit	t	t	1
+1178	2024-09-10 10:35:46.134569+00	direct_edit	t	t	1
+1177	2024-09-10 10:35:24.631662+00	direct_edit	t	t	1
+1176	2024-09-10 10:34:37.526944+00	direct_edit	t	t	1
+1175	2024-09-10 10:34:22.781024+00	direct_edit	t	t	1
+1174	2024-09-10 10:33:50.428653+00	direct_edit	t	t	1
+1173	2024-09-10 10:33:17.025546+00	direct_edit	t	f	1
+1172	2024-09-10 10:33:05.354592+00	direct_edit	t	f	1
+1171	2024-09-10 10:28:43.017777+00	direct_edit	t	t	1
+1179	2024-09-10 10:36:17.624541+00	management	t	f	\N
+1195	2024-09-10 10:40:53.357321+00	direct_edit	t	f	1
+1194	2024-09-10 10:40:49.054053+00	direct_edit	t	f	1
+1193	2024-09-10 10:40:38.8102+00	direct_edit	t	f	1
+1192	2024-09-10 10:40:10.744638+00	direct_edit	t	t	1
+1191	2024-09-10 10:39:48.215218+00	direct_edit	t	t	1
+1190	2024-09-10 10:39:28.122349+00	direct_edit	t	t	1
+1189	2024-09-10 10:39:07.049401+00	direct_edit	t	t	1
+1188	2024-09-10 10:38:41.448708+00	direct_edit	t	t	1
+1187	2024-09-10 10:38:16.062679+00	direct_edit	t	f	1
+1186	2024-09-10 10:38:10.140262+00	direct_edit	t	f	1
+1185	2024-09-10 10:37:59.461945+00	direct_edit	t	t	1
+1184	2024-09-10 10:37:52.088878+00	direct_edit	t	t	1
+1183	2024-09-10 10:37:45.124498+00	direct_edit	t	t	1
+1182	2024-09-10 10:37:36.939331+00	direct_edit	t	t	1
+1181	2024-09-10 10:37:18.913463+00	direct_edit	t	t	1
+1180	2024-09-10 10:37:11.339574+00	direct_edit	t	t	1
+1196	2024-09-10 10:41:26.170354+00	management	t	f	\N
+1197	2024-09-10 10:42:34.309452+00	direct_edit	t	t	1
+1198	2024-09-10 10:42:55.667308+00	management	t	f	\N
+1202	2024-09-10 10:44:00.73906+00	direct_edit	t	f	1
+1201	2024-09-10 10:43:57.465429+00	direct_edit	t	f	1
+1200	2024-09-10 10:43:45.791858+00	direct_edit	t	f	1
+1199	2024-09-10 10:43:43.534028+00	direct_edit	t	f	1
+1203	2024-09-10 10:44:14.757652+00	management	t	f	\N
+1205	2024-09-10 10:48:32.635643+00	management	t	f	\N
+1204	2024-09-10 10:47:35.778796+00	direct_edit	t	t	1
+1206	2024-09-10 10:48:44.226134+00	management	t	f	\N
+1213	2024-09-10 11:02:21.142448+00	direct_edit	t	t	1
+1212	2024-09-10 11:01:57.63076+00	direct_edit	t	t	1
+1211	2024-09-10 11:01:34.242533+00	direct_edit	t	t	1
+1210	2024-09-10 11:01:22.7795+00	direct_edit	t	t	1
+1209	2024-09-10 11:00:59.456046+00	direct_edit	t	t	1
+1208	2024-09-10 10:59:52.863624+00	direct_edit	t	t	1
+1207	2024-09-10 10:59:46.925942+00	direct_edit	t	t	1
+1214	2024-09-10 11:02:52.771715+00	management	t	f	\N
+1227	2024-09-10 12:18:13.775765+00	management	t	f	\N
+1226	2024-09-10 12:17:55.290982+00	direct_edit	t	t	1
+1225	2024-09-10 12:17:39.309157+00	direct_edit	t	t	1
+1224	2024-09-10 12:17:24.571456+00	direct_edit	t	t	1
+1223	2024-09-10 12:17:06.341263+00	direct_edit	t	t	1
+1222	2024-09-10 12:16:50.569837+00	direct_edit	t	t	1
+1221	2024-09-10 12:16:29.065862+00	direct_edit	t	t	1
+1220	2024-09-10 12:15:31.1649+00	direct_edit	t	t	1
+1219	2024-09-10 11:06:44.931091+00	direct_edit	t	t	1
+1218	2024-09-10 11:03:47.981823+00	direct_edit	t	t	1
+1217	2024-09-10 11:03:41.634863+00	direct_edit	t	f	1
+1216	2024-09-10 11:03:37.94683+00	direct_edit	t	f	1
+1215	2024-09-10 11:03:33.239261+00	direct_edit	t	t	1
+1228	2024-09-10 12:18:25.071164+00	management	t	f	\N
+1230	2024-09-10 12:20:36.671186+00	direct_edit	t	t	1
+1229	2024-09-10 12:19:55.335175+00	direct_edit	t	t	1
+1231	2024-09-10 12:21:40.212905+00	management	t	f	\N
+1239	2024-09-10 12:27:50.260162+00	direct_edit	t	t	1
+1238	2024-09-10 12:26:50.892246+00	direct_edit	t	t	1
+1237	2024-09-10 12:26:34.900505+00	direct_edit	t	t	1
+1236	2024-09-10 12:25:49.60828+00	direct_edit	t	f	1
+1235	2024-09-10 12:25:27.295137+00	direct_edit	t	f	1
+1234	2024-09-10 12:25:19.913659+00	direct_edit	t	f	1
+1233	2024-09-10 12:23:27.074047+00	direct_edit	t	t	1
+1232	2024-09-10 12:23:17.85972+00	direct_edit	t	t	1
+1245	2024-09-10 12:34:43.976903+00	direct_edit	t	t	1
+1244	2024-09-10 12:34:32.929968+00	direct_edit	t	t	1
+1243	2024-09-10 12:34:08.621853+00	direct_edit	t	f	1
+1242	2024-09-10 12:29:53.129579+00	direct_edit	t	f	1
+1241	2024-09-10 12:29:48.418817+00	direct_edit	t	f	1
+1240	2024-09-10 12:29:44.331845+00	direct_edit	t	f	1
+1246	2024-09-10 12:35:07.360218+00	management	t	f	\N
+1460	2024-09-24 09:26:09.867117+00	management	t	f	\N
+1255	2024-09-10 13:41:45.300033+00	direct_edit	t	f	1
+1254	2024-09-10 13:41:22.35702+00	direct_edit	t	f	1
+1253	2024-09-10 13:40:51.841158+00	direct_edit	t	f	1
+1252	2024-09-10 13:40:00.841204+00	direct_edit	t	f	1
+1251	2024-09-10 13:29:49.496297+00	direct_edit	t	t	1
+1250	2024-09-10 13:28:45.780241+00	direct_edit	t	t	1
+1249	2024-09-10 13:24:39.433561+00	direct_edit	t	t	1
+1248	2024-09-10 13:20:33.032079+00	direct_edit	t	f	1
+1247	2024-09-10 13:20:22.790597+00	direct_edit	t	f	1
+1256	2024-09-10 13:42:48.157359+00	management	t	f	\N
+1261	2024-09-11 12:29:25.106061+00	direct_edit	t	t	1
+1260	2024-09-11 12:28:51.30691+00	direct_edit	t	t	1
+1259	2024-09-11 12:25:40.227963+00	direct_edit	t	t	1
+1258	2024-09-11 12:25:09.922248+00	direct_edit	t	t	1
+1257	2024-09-11 12:21:56.725799+00	direct_edit	t	t	1
+1262	2024-09-11 13:04:14.763689+00	management	t	f	\N
+1270	2024-09-12 14:52:38.483398+00	direct_edit	t	t	1
+1269	2024-09-12 14:52:26.395897+00	direct_edit	t	f	1
+1268	2024-09-12 14:52:19.234856+00	direct_edit	t	t	1
+1267	2024-09-12 14:52:04.690547+00	direct_edit	t	t	1
+1266	2024-09-12 14:51:54.044696+00	direct_edit	t	t	1
+1265	2024-09-12 14:51:44.21068+00	direct_edit	t	t	1
+1264	2024-09-12 14:51:31.52176+00	direct_edit	t	t	1
+1263	2024-09-12 14:51:19.841867+00	direct_edit	t	t	1
+1271	2024-09-12 14:54:00.590495+00	direct_edit	t	f	1
+1272	2024-09-12 14:55:41.985865+00	direct_edit	t	t	1
+1273	2024-09-12 15:19:36.778805+00	direct_edit	t	t	1
+1276	2024-09-12 15:46:36.388235+00	direct_edit	t	t	1
+1275	2024-09-12 15:46:26.558709+00	direct_edit	t	t	1
+1274	2024-09-12 15:31:08.423966+00	direct_edit	t	t	1
+1277	2024-09-12 15:48:42.772787+00	direct_edit	t	t	1
+1278	2024-09-12 15:50:12.045228+00	direct_edit	t	t	1
+1279	2024-09-12 15:52:41.961572+00	direct_edit	t	t	1
+1284	2024-09-12 15:54:51.198154+00	direct_edit	t	t	1
+1283	2024-09-12 15:54:36.655943+00	direct_edit	t	t	1
+1282	2024-09-12 15:54:20.069994+00	direct_edit	t	t	1
+1281	2024-09-12 15:54:02.455219+00	direct_edit	t	t	1
+1280	2024-09-12 15:53:50.166135+00	direct_edit	t	t	1
+1286	2024-09-12 15:55:47.513854+00	direct_edit	t	t	1
+1285	2024-09-12 15:55:39.116675+00	direct_edit	t	t	1
+1287	2024-09-12 15:56:49.572548+00	direct_edit	t	t	1
+1288	2024-09-12 15:57:09.83227+00	management	t	f	\N
+1290	2024-09-12 15:58:29.768858+00	management	t	f	\N
+1289	2024-09-12 15:58:22.553631+00	direct_edit	t	t	1
+1291	2024-09-12 16:40:57.370124+00	management	t	f	\N
+1299	2024-09-13 09:46:57.590404+00	management	t	f	\N
+1298	2024-09-13 09:46:38.273145+00	direct_edit	t	t	1
+1297	2024-09-13 09:46:06.120767+00	direct_edit	t	t	1
+1296	2024-09-13 09:45:57.694057+00	direct_edit	t	t	1
+1295	2024-09-13 09:45:26.595928+00	direct_edit	t	t	1
+1294	2024-09-13 09:43:33.110826+00	direct_edit	t	t	1
+1293	2024-09-13 09:43:25.525499+00	direct_edit	t	t	1
+1292	2024-09-13 09:42:31.456966+00	direct_edit	t	t	1
+1301	2024-09-13 09:47:58.598763+00	management	t	f	\N
+1300	2024-09-13 09:47:42.791393+00	direct_edit	t	t	1
+1311	2024-09-13 09:52:32.79547+00	management	t	f	\N
+1310	2024-09-13 09:52:17.616863+00	direct_edit	t	f	1
+1309	2024-09-13 09:52:01.63862+00	direct_edit	t	f	1
+1308	2024-09-13 09:51:23.334695+00	direct_edit	t	t	1
+1307	2024-09-13 09:51:18.214351+00	direct_edit	t	t	1
+1306	2024-09-13 09:51:05.518083+00	direct_edit	t	t	1
+1305	2024-09-13 09:50:47.07476+00	direct_edit	t	t	1
+1304	2024-09-13 09:50:26.220617+00	direct_edit	t	t	1
+1303	2024-09-13 09:49:27.857506+00	direct_edit	t	t	1
+1302	2024-09-13 09:48:40.749106+00	direct_edit	t	t	1
+1318	2024-09-13 09:54:08.479852+00	management	t	f	\N
+1317	2024-09-13 09:53:57.350878+00	direct_edit	t	f	1
+1316	2024-09-13 09:53:51.823046+00	direct_edit	t	f	1
+1315	2024-09-13 09:53:46.086056+00	direct_edit	t	f	1
+1314	2024-09-13 09:53:39.330484+00	direct_edit	t	f	1
+1313	2024-09-13 09:53:30.926138+00	direct_edit	t	f	1
+1312	2024-09-13 09:53:21.71681+00	direct_edit	t	t	1
+1323	2024-09-13 09:57:07.100504+00	management	t	f	\N
+1322	2024-09-13 09:56:07.436373+00	direct_edit	t	t	1
+1321	2024-09-13 09:55:53.469571+00	direct_edit	t	t	1
+1320	2024-09-13 09:55:06.363944+00	direct_edit	t	t	1
+1319	2024-09-13 09:54:53.695535+00	direct_edit	t	t	1
+1324	2024-09-13 09:57:18.7182+00	management	t	f	\N
+1330	2024-09-13 10:00:20.828182+00	management	t	f	\N
+1329	2024-09-13 10:00:13.154724+00	direct_edit	t	t	1
+1328	2024-09-13 09:59:49.840141+00	direct_edit	t	t	1
+1327	2024-09-13 09:59:28.954764+00	direct_edit	t	t	1
+1326	2024-09-13 09:59:08.876721+00	direct_edit	t	t	1
+1325	2024-09-13 09:58:31.812257+00	direct_edit	t	t	1
+1331	2024-09-13 10:00:32.546703+00	management	t	f	\N
+1334	2024-09-13 10:02:33.270975+00	management	t	f	\N
+1333	2024-09-13 10:02:25.260072+00	direct_edit	t	t	1
+1332	2024-09-13 10:02:16.071062+00	direct_edit	t	t	1
+1336	2024-09-13 10:03:21.208059+00	management	t	f	\N
+1335	2024-09-13 10:03:13.626379+00	direct_edit	t	t	1
+1338	2024-09-13 10:04:16.748769+00	management	t	f	\N
+1337	2024-09-13 10:04:06.26271+00	direct_edit	t	t	1
+1341	2024-09-13 10:06:17.274559+00	management	t	f	\N
+1340	2024-09-13 10:06:07.8786+00	direct_edit	t	t	1
+1339	2024-09-13 10:05:00.939688+00	direct_edit	t	t	1
+1343	2024-09-13 10:07:04.478183+00	management	t	f	\N
+1342	2024-09-13 10:06:57.468532+00	direct_edit	t	t	1
+1345	2024-09-13 10:07:52.984192+00	management	t	f	\N
+1344	2024-09-13 10:07:46.011761+00	direct_edit	t	t	1
+1348	2024-09-13 10:08:46.48357+00	management	t	f	\N
+1347	2024-09-13 10:08:39.020339+00	direct_edit	t	t	1
+1346	2024-09-13 10:08:29.631386+00	direct_edit	t	t	1
+1350	2024-09-13 10:10:18.42692+00	management	t	f	\N
+1349	2024-09-13 10:10:10.975279+00	direct_edit	t	t	1
+1352	2024-09-13 10:12:15.610325+00	management	t	f	\N
+1351	2024-09-13 10:10:47.841157+00	direct_edit	t	t	1
+1354	2024-09-13 10:13:05.013524+00	management	t	f	\N
+1353	2024-09-13 10:12:59.121993+00	direct_edit	t	t	1
+1358	2024-09-13 10:14:25.413255+00	management	t	f	\N
+1357	2024-09-13 10:14:16.945085+00	direct_edit	t	t	1
+1356	2024-09-13 10:14:11.622835+00	direct_edit	t	t	1
+1355	2024-09-13 10:14:07.297797+00	direct_edit	t	t	1
+1360	2024-09-13 10:15:03.879754+00	management	t	f	\N
+1359	2024-09-13 10:14:56.473102+00	direct_edit	t	t	1
+1362	2024-09-13 10:15:47.602122+00	management	t	f	\N
+1461	2024-09-24 09:26:50.419953+00	management	t	t	\N
+1361	2024-09-13 10:15:41.122242+00	direct_edit	t	t	1
+1364	2024-09-13 10:16:33.767728+00	management	t	f	\N
+1363	2024-09-13 10:16:26.790795+00	direct_edit	t	t	1
+1366	2024-09-13 10:17:17.002324+00	management	t	f	\N
+1365	2024-09-13 10:17:09.184966+00	direct_edit	t	t	1
+1368	2024-09-13 10:17:54.917009+00	management	t	f	\N
+1367	2024-09-13 10:17:45.654775+00	direct_edit	t	t	1
+1376	2024-09-14 07:38:23.226492+00	management	t	f	\N
+1375	2024-09-14 07:37:54.918275+00	direct_edit	t	t	1
+1374	2024-09-14 07:31:41.807829+00	direct_edit	t	t	1
+1373	2024-09-14 07:31:29.894066+00	direct_edit	t	t	1
+1372	2024-09-14 07:31:20.49625+00	direct_edit	t	t	1
+1371	2024-09-14 07:31:06.981565+00	direct_edit	t	t	1
+1370	2024-09-14 07:30:50.598423+00	direct_edit	t	t	1
+1369	2024-09-14 07:30:23.565052+00	direct_edit	t	t	1
+1378	2024-09-14 07:41:40.772276+00	management	t	f	\N
+1377	2024-09-14 07:41:33.68215+00	direct_edit	t	t	1
+1380	2024-09-14 07:44:31.52611+00	management	t	f	\N
+1379	2024-09-14 07:44:24.084008+00	direct_edit	t	t	1
+1381	2024-09-14 07:44:42.796719+00	management	t	f	\N
+1382	2024-09-14 08:07:07.642383+00	management	t	f	\N
+1383	2024-09-14 08:08:06.892598+00	management	t	f	\N
+1392	2024-09-17 07:27:25.135224+00	direct_edit	t	f	1
+1391	2024-09-17 07:21:04.067146+00	direct_edit	t	f	1
+1390	2024-09-17 07:18:17.567738+00	direct_edit	t	f	1
+1389	2024-09-17 07:17:02.403835+00	direct_edit	t	f	1
+1388	2024-09-17 07:13:24.078989+00	direct_edit	t	f	1
+1387	2024-09-17 07:05:02.1913+00	direct_edit	t	f	1
+1386	2024-09-16 11:42:47.35352+00	direct_edit	t	f	1
+1385	2024-09-16 11:40:31.779548+00	direct_edit	t	f	1
+1384	2024-09-16 11:40:10.877233+00	direct_edit	t	f	1
+1393	2024-09-17 07:28:20.104683+00	direct_edit	t	f	1
+1397	2024-09-17 07:51:20.07211+00	direct_edit	t	f	1
+1396	2024-09-17 07:46:27.647246+00	direct_edit	t	t	1
+1395	2024-09-17 07:44:43.784645+00	direct_edit	t	t	1
+1394	2024-09-17 07:29:26.460936+00	direct_edit	t	f	1
+1409	2024-09-17 08:08:34.297084+00	direct_edit	t	t	1
+1408	2024-09-17 08:08:28.562649+00	direct_edit	t	t	1
+1407	2024-09-17 08:08:16.012427+00	direct_edit	t	t	1
+1406	2024-09-17 08:08:10.332891+00	direct_edit	t	t	1
+1405	2024-09-17 08:08:04.802643+00	direct_edit	t	t	1
+1404	2024-09-17 08:07:54.562573+00	direct_edit	t	t	1
+1403	2024-09-17 08:03:38.970107+00	direct_edit	t	t	1
+1402	2024-09-17 08:00:28.296372+00	direct_edit	t	t	1
+1401	2024-09-17 08:00:19.082067+00	direct_edit	t	t	1
+1400	2024-09-17 08:00:07.843568+00	direct_edit	t	t	1
+1399	2024-09-17 07:57:44.266739+00	direct_edit	t	t	1
+1398	2024-09-17 07:53:26.858845+00	direct_edit	t	f	1
+1412	2024-09-17 08:10:25.17003+00	direct_edit	t	t	1
+1411	2024-09-17 08:09:50.072073+00	direct_edit	t	t	1
+1410	2024-09-17 08:09:42.90533+00	direct_edit	t	t	1
+1416	2024-09-17 08:12:17.736897+00	direct_edit	t	t	1
+1415	2024-09-17 08:12:05.857031+00	direct_edit	t	t	1
+1414	2024-09-17 08:12:00.121251+00	direct_edit	t	t	1
+1413	2024-09-17 08:11:11.788843+00	direct_edit	t	t	1
+1417	2024-09-17 08:13:06.272245+00	direct_edit	t	t	1
+1418	2024-09-17 08:13:59.321358+00	direct_edit	t	t	1
+1421	2024-09-17 08:15:17.756792+00	direct_edit	t	t	1
+1420	2024-09-17 08:14:59.12088+00	direct_edit	t	t	1
+1419	2024-09-17 08:14:52.163509+00	direct_edit	t	t	1
+1423	2024-09-17 08:18:21.474712+00	direct_edit	t	t	1
+1422	2024-09-17 08:18:13.689605+00	direct_edit	t	t	1
+1424	2024-09-17 08:20:15.545646+00	direct_edit	t	t	1
+1447	2024-09-17 09:51:43.294892+00	direct_edit	t	t	1
+1446	2024-09-17 09:51:29.159128+00	direct_edit	t	f	1
+1445	2024-09-17 09:51:02.081944+00	direct_edit	t	f	1
+1444	2024-09-17 09:50:26.890106+00	direct_edit	t	t	1
+1443	2024-09-17 09:48:18.483833+00	direct_edit	t	t	1
+1442	2024-09-17 09:46:10.929869+00	direct_edit	t	t	1
+1441	2024-09-17 09:46:03.479578+00	direct_edit	t	t	1
+1440	2024-09-17 09:45:59.588099+00	direct_edit	t	t	1
+1439	2024-09-17 09:45:52.827538+00	direct_edit	t	t	1
+1438	2024-09-17 09:45:46.485474+00	direct_edit	t	t	1
+1437	2024-09-17 09:45:43.407182+00	direct_edit	t	t	1
+1436	2024-09-17 09:45:40.336744+00	direct_edit	t	t	1
+1435	2024-09-17 09:45:33.167597+00	direct_edit	t	t	1
+1434	2024-09-17 09:45:28.660578+00	direct_edit	t	t	1
+1433	2024-09-17 09:45:22.10772+00	direct_edit	t	t	1
+1432	2024-09-17 09:32:36.370708+00	direct_edit	t	f	1
+1431	2024-09-17 09:31:05.023255+00	direct_edit	t	f	1
+1430	2024-09-17 09:30:57.037458+00	direct_edit	t	f	1
+1429	2024-09-17 09:21:36.275858+00	direct_edit	t	f	1
+1428	2024-09-17 09:21:14.154067+00	direct_edit	t	f	1
+1427	2024-09-17 09:17:57.13612+00	direct_edit	t	t	1
+1426	2024-09-17 09:17:50.579633+00	direct_edit	t	f	1
+1425	2024-09-17 09:11:18.984082+00	direct_edit	t	f	1
+1450	2024-09-17 09:57:49.847976+00	direct_edit	t	t	1
+1449	2024-09-17 09:55:01.292517+00	direct_edit	t	t	1
+1448	2024-09-17 09:54:20.130126+00	direct_edit	t	t	1
+1462	2024-09-24 10:04:08.949053+00	management	t	t	\N
+1464	2024-09-26 07:07:03.307946+00	management	t	t	\N
+1466	2024-09-26 07:30:45.077639+00	management	t	t	\N
+1475	2024-09-26 07:42:42.544684+00	direct_edit	t	f	1
+1484	2024-09-26 08:11:34.742136+00	management	t	t	\N
+1493	2024-09-26 08:25:43.432671+00	management	t	t	\N
+1502	2024-09-26 09:49:38.352906+00	direct_edit	t	t	1
+1538	2024-09-26 10:04:34.371102+00	direct_edit	t	t	1
+1529	2024-09-26 10:03:13.271285+00	direct_edit	t	f	1
+1520	2024-09-26 10:01:44.385284+00	direct_edit	t	f	1
+1511	2024-09-26 10:00:21.846249+00	direct_edit	t	f	1
+1547	2024-09-26 10:15:54.970891+00	direct_edit	t	t	1
+1565	2024-10-14 07:43:30.556651+00	direct_edit	t	f	1
+1556	2024-10-14 07:42:25.236643+00	direct_edit	t	f	1
+1574	2024-10-14 07:59:13.073095+00	direct_edit	t	f	1
+1583	2024-10-14 08:06:52.733014+00	direct_edit	t	f	1
+1646	2024-10-14 09:15:48.453187+00	direct_edit	t	f	1
+1637	2024-10-14 09:13:19.559871+00	direct_edit	t	f	1
+1628	2024-10-14 08:37:22.579852+00	direct_edit	t	f	1
+1619	2024-10-14 08:36:31.780933+00	direct_edit	t	f	1
+1610	2024-10-14 08:35:59.622567+00	direct_edit	t	f	1
+1601	2024-10-14 08:32:57.760393+00	direct_edit	t	f	1
+1592	2024-10-14 08:26:29.247563+00	direct_edit	t	f	1
+1655	2024-10-14 09:22:02.24729+00	direct_edit	t	f	1
+1664	2024-10-14 09:38:02.7512+00	direct_edit	t	f	1
+1673	2024-10-14 09:47:00.962367+00	management	t	t	\N
+1682	2024-10-14 09:53:37.872442+00	direct_edit	t	f	1
+1691	2024-10-14 09:58:45.112624+00	management	t	t	\N
+1467	2024-09-26 07:31:54.371969+00	management	t	t	\N
+1476	2024-09-26 07:42:58.255982+00	management	t	t	\N
+1485	2024-09-26 08:16:09.237281+00	direct_edit	t	t	1
+1494	2024-09-26 08:26:20.93681+00	direct_edit	t	t	1
+1503	2024-09-26 09:49:47.073889+00	direct_edit	t	t	1
+1539	2024-09-26 10:05:06.833964+00	management	t	t	\N
+1530	2024-09-26 10:03:26.586659+00	direct_edit	t	f	1
+1521	2024-09-26 10:01:49.092846+00	direct_edit	t	f	1
+1512	2024-09-26 10:00:29.221148+00	direct_edit	t	f	1
+1548	2024-09-26 10:16:06.754154+00	management	t	t	\N
+1566	2024-10-14 07:47:08.014453+00	management	t	t	\N
+1557	2024-10-14 07:42:32.398147+00	direct_edit	t	f	1
+1575	2024-10-14 07:59:25.558589+00	management	t	t	\N
+1584	2024-10-14 08:07:00.817526+00	management	t	t	\N
+1647	2024-10-14 09:15:59.923983+00	direct_edit	t	f	1
+1638	2024-10-14 09:13:56.022618+00	direct_edit	t	f	1
+1629	2024-10-14 08:37:32.193879+00	direct_edit	t	f	1
+1620	2024-10-14 08:36:34.035541+00	direct_edit	t	f	1
+1611	2024-10-14 08:36:02.077794+00	direct_edit	t	f	1
+1602	2024-10-14 08:33:10.660786+00	direct_edit	t	f	1
+1593	2024-10-14 08:26:37.439362+00	direct_edit	t	f	1
+1656	2024-10-14 09:22:15.157528+00	direct_edit	t	f	1
+1665	2024-10-14 09:38:18.700802+00	management	t	t	\N
+1674	2024-10-14 09:48:16.32765+00	direct_edit	t	f	1
+1683	2024-10-14 09:54:10.855695+00	direct_edit	t	f	1
+1692	2024-10-14 09:59:22.143816+00	direct_edit	t	f	1
+1468	2024-09-26 07:35:43.672033+00	management	t	t	\N
+1477	2024-09-26 07:48:28.47175+00	direct_edit	t	t	1
+1486	2024-09-26 08:16:29.469269+00	direct_edit	t	t	1
+1495	2024-09-26 08:26:33.432951+00	direct_edit	t	t	1
+1504	2024-09-26 09:49:54.124328+00	direct_edit	t	t	1
+1531	2024-09-26 10:03:44.205265+00	direct_edit	t	f	1
+1522	2024-09-26 10:01:51.965332+00	direct_edit	t	f	1
+1513	2024-09-26 10:00:34.551498+00	direct_edit	t	f	1
+1540	2024-09-26 10:06:52.821557+00	direct_edit	t	t	1
+1558	2024-10-14 07:42:40.38506+00	direct_edit	t	f	1
+1549	2024-10-14 07:41:38.533546+00	direct_edit	t	f	1
+1567	2024-10-14 07:48:57.680573+00	direct_edit	t	f	1
+1576	2024-10-14 08:00:59.400395+00	direct_edit	t	f	1
+1585	2024-10-14 08:09:33.206094+00	direct_edit	t	f	1
+1648	2024-10-14 09:16:12.619615+00	direct_edit	t	f	1
+1639	2024-10-14 09:14:06.470297+00	direct_edit	t	f	1
+1630	2024-10-14 08:37:33.832333+00	direct_edit	t	f	1
+1621	2024-10-14 08:36:36.901217+00	direct_edit	t	f	1
+1612	2024-10-14 08:36:05.15603+00	direct_edit	t	f	1
+1603	2024-10-14 08:34:35.448399+00	direct_edit	t	t	1
+1594	2024-10-14 08:27:26.389106+00	direct_edit	t	f	1
+1657	2024-10-14 09:22:22.94894+00	management	t	t	\N
+1666	2024-10-14 09:39:13.008294+00	direct_edit	t	f	1
+1675	2024-10-14 09:48:22.655548+00	management	t	t	\N
+1684	2024-10-14 09:54:20.255639+00	management	t	t	\N
+1693	2024-10-14 09:59:30.122254+00	management	t	t	\N
+1469	2024-09-26 07:38:19.155151+00	direct_edit	t	t	1
+1478	2024-09-26 07:49:21.92287+00	direct_edit	t	t	1
+1487	2024-09-26 08:16:51.178104+00	direct_edit	t	t	1
+1496	2024-09-26 08:29:09.919491+00	direct_edit	t	t	1
+1505	2024-09-26 09:50:02.115388+00	direct_edit	t	t	1
+1532	2024-09-26 10:03:47.27035+00	direct_edit	t	f	1
+1523	2024-09-26 10:02:06.712112+00	direct_edit	t	f	1
+1514	2024-09-26 10:00:52.369591+00	direct_edit	t	f	1
+1541	2024-09-26 10:08:47.953783+00	management	t	t	\N
+1559	2024-10-14 07:42:44.694661+00	direct_edit	t	f	1
+1550	2024-10-14 07:41:40.995795+00	direct_edit	t	f	1
+1568	2024-10-14 07:49:07.499496+00	direct_edit	t	f	1
+1577	2024-10-14 08:01:12.515093+00	direct_edit	t	f	1
+1586	2024-10-14 08:09:41.771586+00	management	t	t	\N
+1649	2024-10-14 09:16:25.304951+00	management	t	t	\N
+1640	2024-10-14 09:14:13.628584+00	direct_edit	t	f	1
+1631	2024-10-14 08:37:36.911522+00	direct_edit	t	f	1
+1622	2024-10-14 08:36:48.994384+00	direct_edit	t	f	1
+1613	2024-10-14 08:36:09.042423+00	direct_edit	t	f	1
+1604	2024-10-14 08:34:42.819696+00	direct_edit	t	f	1
+1595	2024-10-14 08:27:30.891749+00	direct_edit	t	f	1
+1658	2024-10-14 09:24:46.051051+00	direct_edit	t	f	1
+1667	2024-10-14 09:41:08.674406+00	management	t	t	\N
+1676	2024-10-14 09:50:36.830452+00	direct_edit	t	f	1
+1685	2024-10-14 09:56:31.145849+00	direct_edit	t	f	1
+1470	2024-09-26 07:38:30.01308+00	management	t	t	\N
+1479	2024-09-26 07:49:39.561913+00	direct_edit	t	t	1
+1488	2024-09-26 08:17:03.261658+00	direct_edit	t	t	1
+1497	2024-09-26 08:29:52.871375+00	management	t	t	\N
+1506	2024-09-26 09:50:46.179522+00	direct_edit	t	f	1
+1533	2024-09-26 10:04:00.171117+00	direct_edit	t	f	1
+1524	2024-09-26 10:02:16.749619+00	direct_edit	t	f	1
+1515	2024-09-26 10:00:55.854845+00	direct_edit	t	f	1
+1542	2024-09-26 10:10:07.012276+00	direct_edit	t	t	1
+1560	2024-10-14 07:42:48.792562+00	direct_edit	t	f	1
+1551	2024-10-14 07:41:46.943402+00	direct_edit	t	t	1
+1569	2024-10-14 07:49:17.024828+00	direct_edit	t	f	1
+1578	2024-10-14 08:01:26.629597+00	direct_edit	t	f	1
+1587	2024-10-14 08:11:24.619805+00	direct_edit	t	f	1
+1641	2024-10-14 09:14:19.569443+00	direct_edit	t	f	1
+1632	2024-10-14 08:37:41.208229+00	direct_edit	t	f	1
+1623	2024-10-14 08:36:51.236409+00	direct_edit	t	f	1
+1614	2024-10-14 08:36:12.72773+00	direct_edit	t	f	1
+1605	2024-10-14 08:34:55.107253+00	direct_edit	t	f	1
+1596	2024-10-14 08:27:54.241424+00	direct_edit	t	f	1
+1650	2024-10-14 09:17:53.585831+00	direct_edit	t	f	1
+1659	2024-10-14 09:24:53.004838+00	management	t	t	\N
+1668	2024-10-14 09:44:10.394599+00	direct_edit	t	f	1
+1677	2024-10-14 09:50:44.846528+00	management	t	t	\N
+1686	2024-10-14 09:56:44.050708+00	direct_edit	t	f	1
+1471	2024-09-26 07:38:57.446861+00	direct_edit	t	f	1
+1480	2024-09-26 07:50:10.845706+00	direct_edit	t	t	1
+1489	2024-09-26 08:17:11.45662+00	direct_edit	t	t	1
+1498	2024-09-26 09:40:18.444027+00	direct_edit	t	t	1
+1507	2024-09-26 09:57:56.001745+00	management	t	t	\N
+1534	2024-09-26 10:04:06.518797+00	direct_edit	t	f	1
+1525	2024-09-26 10:02:39.690126+00	direct_edit	t	f	1
+1516	2024-09-26 10:00:59.94124+00	direct_edit	t	f	1
+1543	2024-09-26 10:11:36.710816+00	direct_edit	t	f	1
+1561	2024-10-14 07:42:58.211412+00	direct_edit	t	f	1
+1552	2024-10-14 07:41:54.924809+00	direct_edit	t	f	1
+1570	2024-10-14 07:49:25.460115+00	management	t	t	\N
+1579	2024-10-14 08:02:28.456476+00	direct_edit	t	t	1
+1588	2024-10-14 08:11:30.55195+00	management	t	t	\N
+1642	2024-10-14 09:14:49.056757+00	direct_edit	t	f	1
+1633	2024-10-14 08:37:43.872311+00	direct_edit	t	f	1
+1624	2024-10-14 08:36:53.284849+00	direct_edit	t	f	1
+1615	2024-10-14 08:36:17.643729+00	direct_edit	t	f	1
+1606	2024-10-14 08:35:35.872762+00	direct_edit	t	t	1
+1597	2024-10-14 08:28:08.375584+00	direct_edit	t	f	1
+1651	2024-10-14 09:18:04.222893+00	management	t	t	\N
+1660	2024-10-14 09:30:58.798038+00	direct_edit	t	f	1
+1669	2024-10-14 09:44:51.342677+00	management	t	t	\N
+1678	2024-10-14 09:51:21.268761+00	direct_edit	t	f	1
+1687	2024-10-14 09:57:08.407394+00	direct_edit	t	f	1
+1472	2024-09-26 07:39:07.477781+00	management	t	t	\N
+1481	2024-09-26 07:50:29.278483+00	direct_edit	t	t	1
+1490	2024-09-26 08:17:51.221735+00	direct_edit	t	t	1
+1499	2024-09-26 09:48:35.893205+00	management	t	t	\N
+1535	2024-09-26 10:04:10.823677+00	direct_edit	t	f	1
+1526	2024-09-26 10:02:43.997566+00	direct_edit	t	f	1
+1517	2024-09-26 10:01:27.179627+00	direct_edit	t	f	1
+1508	2024-09-26 09:58:46.616902+00	direct_edit	t	t	1
+1544	2024-09-26 10:13:38.548988+00	direct_edit	t	t	1
+1562	2024-10-14 07:43:01.282515+00	direct_edit	t	f	1
+1553	2024-10-14 07:42:02.09414+00	direct_edit	t	f	1
+1571	2024-10-14 07:58:34.540077+00	direct_edit	t	f	1
+1580	2024-10-14 08:02:46.362294+00	management	t	t	\N
+1643	2024-10-14 09:15:06.874703+00	direct_edit	t	f	1
+1634	2024-10-14 09:12:47.203034+00	direct_edit	t	f	1
+1625	2024-10-14 08:36:57.176022+00	direct_edit	t	f	1
+1616	2024-10-14 08:36:20.722192+00	direct_edit	t	f	1
+1607	2024-10-14 08:35:39.759403+00	direct_edit	t	t	1
+1598	2024-10-14 08:28:18.40645+00	direct_edit	t	f	1
+1589	2024-10-14 08:14:31.198129+00	direct_edit	t	f	1
+1652	2024-10-14 09:18:41.316411+00	direct_edit	t	f	1
+1661	2024-10-14 09:31:06.359922+00	management	t	t	\N
+1670	2024-10-14 09:46:33.115552+00	direct_edit	t	f	1
+1679	2024-10-14 09:51:33.620681+00	management	t	t	\N
+1688	2024-10-14 09:57:23.575567+00	direct_edit	t	f	1
+1473	2024-09-26 07:40:45.156097+00	management	t	t	\N
+1482	2024-09-26 07:54:22.979359+00	direct_edit	t	t	1
+1491	2024-09-26 08:18:23.962267+00	direct_edit	t	t	1
+1500	2024-09-26 09:49:21.765432+00	direct_edit	t	t	1
+1536	2024-09-26 10:04:14.711941+00	direct_edit	t	f	1
+1527	2024-09-26 10:02:46.857999+00	direct_edit	t	f	1
+1518	2024-09-26 10:01:30.865264+00	direct_edit	t	f	1
+1509	2024-09-26 09:58:56.65741+00	direct_edit	t	t	1
+1545	2024-09-26 10:13:50.617381+00	direct_edit	t	t	1
+1563	2024-10-14 07:43:11.52314+00	direct_edit	t	f	1
+1554	2024-10-14 07:42:13.562517+00	direct_edit	t	f	1
+1572	2024-10-14 07:58:51.157162+00	direct_edit	t	f	1
+1581	2024-10-14 08:05:56.745213+00	direct_edit	t	t	1
+1644	2024-10-14 09:15:20.599362+00	direct_edit	t	f	1
+1635	2024-10-14 09:12:53.139439+00	direct_edit	t	f	1
+1626	2024-10-14 08:37:06.806701+00	direct_edit	t	f	1
+1617	2024-10-14 08:36:26.046949+00	direct_edit	t	f	1
+1608	2024-10-14 08:35:44.023856+00	direct_edit	t	f	1
+1599	2024-10-14 08:28:42.181576+00	direct_edit	t	f	1
+1590	2024-10-14 08:26:19.20971+00	direct_edit	t	f	1
+1653	2024-10-14 09:18:50.755437+00	management	t	t	\N
+1662	2024-10-14 09:32:48.402875+00	direct_edit	t	f	1
+1671	2024-10-14 09:46:41.322179+00	direct_edit	t	f	1
+1680	2024-10-14 09:52:39.090567+00	direct_edit	t	f	1
+1689	2024-10-14 09:57:34.040624+00	management	t	t	\N
+1474	2024-09-26 07:42:29.674239+00	direct_edit	t	t	1
+1483	2024-09-26 07:58:04.543571+00	management	t	t	\N
+1492	2024-09-26 08:18:33.581381+00	direct_edit	t	t	1
+1501	2024-09-26 09:49:31.389063+00	direct_edit	t	t	1
+1537	2024-09-26 10:04:18.193127+00	direct_edit	t	f	1
+1528	2024-09-26 10:03:00.16993+00	direct_edit	t	f	1
+1519	2024-09-26 10:01:38.647719+00	direct_edit	t	f	1
+1510	2024-09-26 10:00:12.015625+00	direct_edit	t	f	1
+1546	2024-09-26 10:14:33.200347+00	management	t	t	\N
+1564	2024-10-14 07:43:15.62323+00	direct_edit	t	f	1
+1555	2024-10-14 07:42:21.134923+00	direct_edit	t	f	1
+1573	2024-10-14 07:58:55.666249+00	direct_edit	t	f	1
+1582	2024-10-14 08:06:10.672704+00	management	t	t	\N
+1645	2024-10-14 09:15:38.420506+00	direct_edit	t	f	1
+1636	2024-10-14 09:13:09.52928+00	direct_edit	t	f	1
+1627	2024-10-14 08:37:16.430538+00	direct_edit	t	f	1
+1618	2024-10-14 08:36:28.301877+00	direct_edit	t	f	1
+1609	2024-10-14 08:35:55.32481+00	direct_edit	t	t	1
+1600	2024-10-14 08:32:50.384939+00	direct_edit	t	f	1
+1591	2024-10-14 08:26:23.104212+00	direct_edit	t	f	1
+1654	2024-10-14 09:21:43.836395+00	direct_edit	t	f	1
+1663	2024-10-14 09:37:44.111677+00	direct_edit	t	t	1
+1672	2024-10-14 09:46:51.753904+00	direct_edit	t	f	1
+1681	2024-10-14 09:52:47.471178+00	management	t	t	\N
+1690	2024-10-14 09:58:36.302143+00	direct_edit	t	f	1
+1465	2024-09-26 07:07:49.438347+00	management	t	t	\N
+1694	2024-10-14 10:11:32.671043+00	management	t	t	\N
+1696	2024-10-14 10:23:51.222383+00	management	t	t	\N
+1695	2024-10-14 10:23:43.84118+00	direct_edit	t	f	1
+1699	2024-10-14 10:27:01.543045+00	management	t	t	\N
+1698	2024-10-14 10:26:54.099375+00	direct_edit	t	f	1
+1697	2024-10-14 10:25:00.434511+00	direct_edit	t	f	1
+1700	2024-10-14 10:35:23.941986+00	management	t	t	\N
+1702	2024-10-14 10:35:38.393384+00	management	t	t	\N
+1701	2024-10-14 10:35:32.664991+00	direct_edit	t	f	1
+1704	2024-10-14 10:42:51.211+00	management	t	t	\N
+1703	2024-10-14 10:42:42.736223+00	direct_edit	t	f	1
+1705	2024-10-14 10:44:39.470984+00	management	t	t	\N
+1708	2024-10-14 10:48:06.994629+00	management	t	t	\N
+1707	2024-10-14 10:47:59.978441+00	direct_edit	t	f	1
+1706	2024-10-14 10:45:22.311998+00	direct_edit	t	f	1
+1715	2024-10-14 10:54:23.789031+00	management	t	t	\N
+1714	2024-10-14 10:53:54.304584+00	direct_edit	t	f	1
+1713	2024-10-14 10:53:24.396856+00	direct_edit	t	f	1
+1712	2024-10-14 10:52:59.410632+00	direct_edit	t	f	1
+1711	2024-10-14 10:50:59.146135+00	direct_edit	t	f	1
+1710	2024-10-14 10:50:26.011795+00	direct_edit	t	f	1
+1709	2024-10-14 10:49:52.428081+00	direct_edit	t	f	1
+1718	2024-10-14 12:20:16.611694+00	management	t	t	\N
+1717	2024-10-14 12:20:09.09036+00	direct_edit	t	f	1
+1716	2024-10-14 12:19:37.95791+00	direct_edit	t	f	1
+1719	2024-10-14 12:22:02.195387+00	management	t	t	\N
+1723	2024-10-14 12:30:31.691898+00	management	t	t	\N
+1722	2024-10-14 12:29:01.759267+00	direct_edit	t	t	1
+1721	2024-10-14 12:28:17.949207+00	direct_edit	t	t	1
+1720	2024-10-14 12:27:25.927843+00	direct_edit	t	t	1
+1725	2024-10-14 12:31:30.893196+00	management	t	t	\N
+1724	2024-10-14 12:31:17.535758+00	direct_edit	t	t	1
+1728	2024-10-14 12:32:27.748725+00	management	t	t	\N
+1727	2024-10-14 12:32:20.084137+00	direct_edit	t	t	1
+1726	2024-10-14 12:32:14.473308+00	direct_edit	t	t	1
+1730	2024-10-14 12:36:00.833629+00	management	t	t	\N
+1729	2024-10-14 12:35:14.527524+00	direct_edit	t	t	1
+1739	2024-10-14 12:40:18.251126+00	management	t	t	\N
+1738	2024-10-14 12:40:10.044146+00	direct_edit	t	f	1
+1737	2024-10-14 12:39:50.589335+00	direct_edit	t	f	1
+1736	2024-10-14 12:39:34.197076+00	direct_edit	t	f	1
+1735	2024-10-14 12:39:23.352926+00	direct_edit	t	f	1
+1734	2024-10-14 12:39:01.422917+00	direct_edit	t	f	1
+1733	2024-10-14 12:37:02.267928+00	direct_edit	t	f	1
+1732	2024-10-14 12:36:53.043007+00	direct_edit	t	f	1
+1731	2024-10-14 12:36:48.538728+00	direct_edit	t	t	1
+1742	2024-10-14 12:48:23.395417+00	management	t	t	\N
+1741	2024-10-14 12:44:17.439792+00	direct_edit	t	t	1
+1740	2024-10-14 12:44:09.447739+00	direct_edit	t	t	1
+1743	2024-10-14 12:48:34.637638+00	management	t	t	\N
+1745	2024-10-14 12:54:08.270301+00	management	t	t	\N
+1744	2024-10-14 12:52:21.005875+00	direct_edit	t	t	1
+1749	2024-10-14 12:56:39.387991+00	management	t	t	\N
+1748	2024-10-14 12:56:32.352144+00	direct_edit	t	t	1
+1747	2024-10-14 12:55:09.746827+00	direct_edit	t	t	1
+1746	2024-10-14 12:54:37.171423+00	direct_edit	t	f	1
+1755	2024-10-14 12:59:57.859694+00	management	t	t	\N
+1754	2024-10-14 12:58:48.262633+00	direct_edit	t	f	1
+1753	2024-10-14 12:58:22.049434+00	direct_edit	t	f	1
+1752	2024-10-14 12:57:49.279354+00	direct_edit	t	f	1
+1751	2024-10-14 12:57:33.507269+00	direct_edit	t	f	1
+1750	2024-10-14 12:57:24.493498+00	direct_edit	t	f	1
+1757	2024-10-24 13:16:51.718189+00	management	t	t	\N
+1756	2024-10-18 09:49:53.311021+00	direct_edit	t	f	1
+1761	2024-10-24 13:20:06.907445+00	management	t	t	\N
+1760	2024-10-24 13:19:56.019943+00	direct_edit	t	t	1
+1759	2024-10-24 13:18:53.332804+00	direct_edit	t	f	1
+1758	2024-10-24 13:17:52.697184+00	direct_edit	t	f	1
+1766	2024-10-24 13:24:02.57539+00	management	t	t	\N
+1765	2024-10-24 13:23:54.202272+00	direct_edit	t	t	1
+1764	2024-10-24 13:23:14.444768+00	direct_edit	t	f	1
+1763	2024-10-24 13:22:22.251781+00	direct_edit	t	t	1
+1762	2024-10-24 13:21:45.137678+00	direct_edit	t	t	1
+1773	2024-10-24 13:29:43.594563+00	management	t	t	\N
+1772	2024-10-24 13:29:36.025806+00	direct_edit	t	f	1
+1771	2024-10-24 13:29:17.595969+00	direct_edit	t	f	1
+1770	2024-10-24 13:28:59.98065+00	direct_edit	t	f	1
+1769	2024-10-24 13:28:29.852193+00	direct_edit	t	f	1
+1768	2024-10-24 13:28:22.598123+00	direct_edit	t	f	1
+1767	2024-10-24 13:28:09.564467+00	direct_edit	t	f	1
+1820	2024-10-25 10:03:45.949335+00	management	t	t	\N
+1819	2024-10-25 10:03:24.25572+00	direct_edit	t	f	1
+1818	2024-10-25 10:03:18.725972+00	direct_edit	t	t	1
+1817	2024-10-25 10:03:07.249371+00	direct_edit	t	f	1
+1816	2024-10-25 10:02:38.999621+00	direct_edit	t	f	1
+1815	2024-10-25 10:02:28.138342+00	direct_edit	t	f	1
+1814	2024-10-25 10:02:18.922037+00	direct_edit	t	f	1
+1813	2024-10-25 10:02:16.260526+00	direct_edit	t	f	1
+1812	2024-10-25 10:02:13.400114+00	direct_edit	t	f	1
+1811	2024-10-25 10:02:09.706571+00	direct_edit	t	f	1
+1810	2024-10-25 10:01:58.851573+00	direct_edit	t	f	1
+1809	2024-10-25 10:01:54.961302+00	direct_edit	t	f	1
+1808	2024-10-25 10:01:51.068408+00	direct_edit	t	f	1
+1807	2024-10-25 10:01:40.216588+00	direct_edit	t	f	1
+1806	2024-10-25 10:01:33.052438+00	direct_edit	t	f	1
+1805	2024-10-25 10:01:25.674626+00	direct_edit	t	f	1
+1804	2024-10-25 10:01:12.970707+00	direct_edit	t	t	1
+1803	2024-10-25 10:01:09.082121+00	direct_edit	t	t	1
+1802	2024-10-25 10:00:55.156445+00	direct_edit	t	f	1
+1801	2024-10-25 10:00:50.650989+00	direct_edit	t	f	1
+1800	2024-10-25 10:00:34.671144+00	direct_edit	t	f	1
+1799	2024-10-25 10:00:29.962403+00	direct_edit	t	f	1
+1798	2024-10-25 10:00:25.456775+00	direct_edit	t	f	1
+1797	2024-10-25 10:00:11.325123+00	direct_edit	t	f	1
+1796	2024-10-25 10:00:03.757279+00	direct_edit	t	f	1
+1795	2024-10-25 10:00:01.296026+00	direct_edit	t	f	1
+1794	2024-10-25 09:59:56.994033+00	direct_edit	t	f	1
+1793	2024-10-25 09:59:37.327769+00	direct_edit	t	f	1
+1792	2024-10-25 09:59:22.991846+00	direct_edit	t	f	1
+1791	2024-10-25 09:58:53.711551+00	direct_edit	t	f	1
+1790	2024-10-25 09:58:50.45456+00	direct_edit	t	f	1
+1789	2024-10-25 09:58:46.136691+00	direct_edit	t	f	1
+1788	2024-10-25 09:58:37.323695+00	direct_edit	t	f	1
+1787	2024-10-25 09:58:26.681188+00	direct_edit	t	f	1
+1786	2024-10-25 09:58:20.533115+00	direct_edit	t	f	1
+1785	2024-10-25 09:57:57.180209+00	direct_edit	t	t	1
+1784	2024-10-25 09:57:36.728002+00	direct_edit	t	t	1
+1783	2024-10-25 09:56:45.337499+00	direct_edit	t	t	1
+1782	2024-10-25 09:55:27.487324+00	direct_edit	t	t	1
+1781	2024-10-25 09:54:14.962113+00	direct_edit	t	t	1
+1780	2024-10-25 09:53:59.333346+00	direct_edit	t	t	1
+1779	2024-10-25 09:52:11.513594+00	direct_edit	t	t	1
+1778	2024-10-25 09:50:00.644331+00	direct_edit	t	t	1
+1777	2024-10-25 09:49:30.695085+00	direct_edit	t	t	1
+1776	2024-10-25 09:49:25.774557+00	direct_edit	t	t	1
+1775	2024-10-25 09:49:07.764364+00	direct_edit	t	t	1
+1774	2024-10-25 09:48:15.789307+00	direct_edit	t	t	1
+1821	2024-10-25 10:05:31.268637+00	direct_edit	t	t	1
+1823	2024-10-27 10:10:35.458945+00	changeset	t	f	1
+1824	2024-10-28 10:35:30.293755+00	changeset	t	t	1
+1826	2024-10-28 10:55:32.591081+00	changeset	t	f	1
+1822	2024-10-25 10:45:52.97078+00	management	t	t	\N
+1825	2024-10-28 10:40:03.615804+00	changeset	t	t	1
+1827	2024-10-28 12:43:01.236283+00	management	f	t	\N
 \.
 
 
@@ -6434,7 +6472,6 @@ COPY public.mapdata_obstaclegroup (id, titles, color, in_legend) FROM stdin;
 --
 
 COPY public.mapdata_poi (locationslug_ptr_id, titles, can_search, can_describe, geometry, access_restriction_id, space_id, import_tag, icon, label_overrides, label_settings_id, external_url, import_block_data, import_block_geom) FROM stdin;
-106	{"en": "Access to President's Office"}	t	t	{"type": "Point", "coordinates": [273.99, 200.93]}	\N	105	\N	\N	{}	\N	\N	f	f
 73	{"en": "Main Entrance"}	t	t	{"type": "Point", "coordinates": [241.75, 129.06]}	\N	61	\N	\N	{}	2	\N	f	f
 74	{"en": "Car Entrance"}	t	t	{"type": "Point", "coordinates": [394.5, 125.44]}	\N	60	\N	\N	{}	2	\N	f	f
 128	{"en": "Restaurant Alumix"}	t	f	{"type": "Point", "coordinates": [199.57, 114.91]}	\N	127	\N	\N	{}	\N	\N	f	f
@@ -6443,6 +6480,8 @@ COPY public.mapdata_poi (locationslug_ptr_id, titles, can_search, can_describe, 
 147	{"en": "Car Park Payment Machine"}	t	f	{"type": "Point", "coordinates": [274.29, 153.72]}	\N	35	\N	\N	{}	\N	\N	f	f
 149	{"en": "ATM"}	t	f	{"type": "Point", "coordinates": [272.33, 142.92]}	\N	95	\N	\N	{}	\N	\N	f	f
 72	{"en": "Entrance (A2)"}	t	t	{"type": "Point", "coordinates": [428.38, 200.0]}	\N	61	\N	\N	{}	2	\N	f	f
+153	{"en": "Crane Hall BOF meetings"}	t	t	{"type": "Point", "coordinates": [222.31, 217.56]}	\N	36	\N	\N	{}	1	https://www.sfscon.it/tracks/crane-hall-bof-meetings-2024/	f	f
+106	{"en": "Access to President's Office (NOI Board)"}	t	t	{"type": "Point", "coordinates": [273.99, 200.93]}	\N	105	\N	\N	{}	\N	\N	f	f
 \.
 
 
@@ -6554,6 +6593,7 @@ COPY public.mapdata_space (locationslug_ptr_id, titles, can_search, can_describe
 44	{"en": "NOI Techpark InfoDesk"}	t	t	{"type": "Polygon", "coordinates": [[[272.65, 225.14], [269.09, 225.14], [269.09, 229.5], [272.65, 229.5], [272.65, 225.14]]]}	\N	f	{}	f	\N	2	\N	\N	{}	\N	\N	f	f
 47	{"en": "WC"}	t	t	{"type": "Polygon", "coordinates": [[[344.15, 207.31], [352.44, 207.31], [352.44, 201.31], [345.35, 201.31], [345.35, 197.45], [343.69, 197.45], [343.69, 200.94], [344.15, 200.94], [344.15, 207.31]]]}	\N	f	{}	f	\N	2	\N	\N	{}	\N	\N	f	f
 51	{"en": "Open Theather"}	t	t	{"type": "Polygon", "coordinates": [[[284.04, 222.39], [284.04, 211.96], [301.6, 211.96], [301.6, 222.42], [284.04, 222.39]]]}	\N	t	{}	f	\N	10	\N	\N	{}	\N	\N	f	f
+127	{"en": "Alumix entrance"}	f	f	{"type": "Polygon", "coordinates": [[[198.82, 114.05], [198.77, 115.5], [200.53, 115.55], [200.48, 114.05], [198.82, 114.05]]]}	\N	f	{}	f	\N	2	\N	\N	{}	\N	\N	f	f
 49	{"en": "Corridor"}	f	t	{"type": "Polygon", "coordinates": [[[338.78, 201.23], [338.78, 190.63], [343.28, 190.63], [343.34, 190.87], [348.51, 190.87], [348.51, 188.95], [350.88, 188.95], [350.88, 195.59], [343.29, 195.59], [343.29, 201.25], [338.78, 201.23]]]}	\N	f	{}	f	\N	2	\N	\N	{}	2	\N	f	f
 46	{"en": "Multimedia Center"}	f	t	{"type": "Polygon", "coordinates": [[[342.82, 207.55], [343.83, 207.55], [343.83, 207.2], [360.03, 207.2], [360.03, 197.25], [338.99, 197.25], [338.99, 197.45], [338.62, 197.45], [338.62, 202.5], [342.78, 202.5], [342.78, 203.22], [343.57, 203.22], [343.57, 205.37], [342.83, 205.37], [342.82, 207.55]]]}	\N	f	{}	f	\N	38	\N	\N	{}	\N	\N	f	f
 40	{"en": "WC for Men"}	t	t	{"type": "Polygon", "coordinates": [[[267.12, 206.09], [267.11, 207.16], [266.89, 207.16], [266.9, 208.67], [270.3, 208.68], [270.3, 206.08], [267.12, 206.09]]]}	\N	f	{}	f	\N	2	\N	\N	{}	\N	\N	f	f
@@ -6583,6 +6623,8 @@ COPY public.mapdata_space (locationslug_ptr_id, titles, can_search, can_describe
 107	{"en": "Stairs B"}	f	f	{"type": "Polygon", "coordinates": [[[266.97, 233.92], [272.74, 233.92], [272.73, 232.33], [268.76, 232.33], [268.77, 231.89], [272.73, 231.89], [272.73, 230.31], [266.97, 230.31], [266.97, 233.92]]]}	\N	f	{}	f	\N	82	\N	\N	{}	\N	\N	f	f
 102	{}	f	f	{"type": "Polygon", "coordinates": [[[266.97, 233.94], [272.75, 233.94], [272.75, 230.34], [266.97, 230.34], [266.97, 233.94]]]}	\N	f	{}	f	\N	38	\N	\N	{}	\N	\N	f	f
 35	{"en": "Car Park Level -2"}	t	t	{"type": "Polygon", "coordinates": [[[367.13, 157.98], [367.13, 180.44], [350.0, 180.44], [350.0, 183.19], [299.12, 183.19], [299.12, 180.56], [283.56, 180.56], [283.56, 183.31], [274.81, 183.31], [274.81, 179.37], [272.69, 179.37], [272.69, 173.12], [268.0, 173.12], [268.0, 156.12], [269.88, 156.12], [269.88, 153.37], [334.06, 153.37], [334.06, 157.98], [367.13, 157.98]]]}	\N	f	{}	f	\N	34	carpark	\N	{}	\N	\N	f	f
+32	{"en": "Corridor Main Lobby - Crane Hall"}	f	t	{"type": "Polygon", "coordinates": [[[271.86, 224.91], [259.65, 224.91], [259.65, 223.58], [271.86, 223.58], [271.86, 224.91]]]}	\N	f	{}	f	\N	2	\N	\N	{}	\N	\N	f	f
+93	{"en": "Noisteria Bar"}	t	t	{"type": "Polygon", "coordinates": [[[272.35, 137.07], [251.29, 135.14], [252.34, 124.92], [252.79, 124.22], [253.29, 123.74], [253.85, 123.36], [254.68, 122.99], [264.98, 123.97], [265.19, 121.84], [273.66, 122.61], [272.35, 137.07]]]}	\N	f	{}	f	\N	2	\N	\N	{}	\N	\N	f	f
 80	{"en": "Car Ramp"}	t	t	{"type": "Polygon", "coordinates": [[[335.8, 155.2], [335.2, 156.29], [334.55, 157.98], [341.05, 157.98], [341.05, 157.78], [342.07, 157.07], [343.12, 156.77], [350.82, 156.73], [353.91, 157.02], [354.92, 157.34], [355.44, 157.62], [355.84, 157.94], [355.84, 158.02], [362.3, 158.03], [361.84, 156.82], [361.26, 155.68], [360.56, 154.73], [359.63, 153.73], [358.53, 152.9], [357.19, 152.16], [355.89, 151.67], [354.83, 151.42], [351.13, 151.08], [343.14, 151.06], [341.79, 151.23], [340.49, 151.57], [339.46, 152.06], [338.54, 152.56], [336.83, 153.94], [335.8, 155.2]]]}	\N	f	{}	f	\N	77	\N	\N	{}	\N	\N	f	f
 81	{"en": "Car Ramp"}	t	t	{"type": "Polygon", "coordinates": [[[335.8, 155.2], [335.2, 156.29], [334.55, 157.98], [341.05, 157.98], [341.05, 157.78], [342.07, 157.07], [343.12, 156.77], [350.82, 156.73], [353.91, 157.02], [364.32, 158.05], [364.86, 152.13], [354.29, 151.1], [351.13, 151.08], [343.15, 151.04], [341.79, 151.23], [340.49, 151.57], [339.46, 152.06], [338.54, 152.56], [336.83, 153.94], [335.8, 155.2]]]}	\N	f	{}	f	\N	11	\N	\N	{}	\N	\N	f	f
 86	{"en": "Stairs B"}	t	t	{"type": "Polygon", "coordinates": [[[338.52, 203.55], [339.8, 203.55], [339.8, 206.23], [342.86, 206.24], [342.86, 207.6], [338.52, 207.6], [338.52, 203.55]]]}	\N	f	{}	f	\N	85	\N	\N	{}	\N	\N	f	f
@@ -6598,9 +6640,6 @@ COPY public.mapdata_space (locationslug_ptr_id, titles, can_search, can_describe
 116	{"en": "WC for Men"}	t	t	{"type": "Polygon", "coordinates": [[[267.12, 206.09], [267.11, 207.16], [266.89, 207.16], [266.9, 208.67], [270.3, 208.68], [270.3, 206.08], [267.12, 206.09]]]}	\N	f	{}	f	\N	38	\N	\N	{}	\N	\N	f	f
 118	{"en": "Open Theather Steps"}	t	t	{"type": "Polygon", "coordinates": [[[284.05, 212.09], [284.05, 194.38], [301.53, 194.38], [301.53, 212.09], [284.05, 212.09]]]}	\N	f	{}	f	\N	11	\N	\N	{}	\N	\N	f	f
 117	{"en": "Corridor"}	f	f	{"type": "Polygon", "coordinates": [[[263.85, 207.03], [263.82, 201.33], [270.54, 201.3], [270.54, 199.69], [272.73, 199.69], [272.73, 203.64], [272.43, 203.64], [272.43, 205.89], [270.62, 205.89], [270.62, 203.47], [266.91, 203.47], [266.91, 207.0], [263.85, 207.03]]]}	\N	f	{}	f	\N	38	\N	\N	{}	\N	\N	f	f
-127	{"en": "Alumix entrance"}	f	f	{"type": "Polygon", "coordinates": [[[198.82, 114.05], [198.77, 115.5], [200.53, 115.55], [200.48, 114.05], [198.82, 114.05]]]}	\N	f	{}	f	\N	2	\N	\N	{}	\N	\N	f	f
-32	{"en": "Corridor Main Lobby - Crane Hall"}	f	t	{"type": "Polygon", "coordinates": [[[271.86, 224.91], [259.65, 224.91], [259.65, 223.58], [271.86, 223.58], [271.86, 224.91]]]}	\N	f	{}	f	\N	2	\N	\N	{}	\N	\N	f	f
-93	{"en": "Noisteria Bar"}	t	t	{"type": "Polygon", "coordinates": [[[272.35, 137.07], [251.29, 135.14], [252.34, 124.92], [252.79, 124.22], [253.29, 123.74], [253.85, 123.36], [254.68, 122.99], [264.98, 123.97], [265.19, 121.84], [273.66, 122.61], [272.35, 137.07]]]}	\N	f	{}	f	\N	2	\N	\N	{}	\N	\N	f	f
 94	{"en": "Noisteria Restaurant"}	t	t	{"type": "Polygon", "coordinates": [[[277.93, 143.73], [278.45, 138.26], [278.8, 138.32], [280.22, 123.24], [300.23, 125.07], [298.3, 145.79], [277.93, 143.73]]]}	\N	f	{}	f	\N	2	\N	\N	{}	\N	\N	f	f
 95	{"en": "Entrance"}	f	f	{"type": "Polygon", "coordinates": [[[277.46, 143.69], [271.82, 143.16], [271.97, 141.6], [274.01, 141.78], [274.22, 139.46], [272.17, 139.25], [272.35, 137.59], [274.34, 137.77], [276.8, 138.01], [276.39, 142.09], [276.65, 142.12], [277.04, 137.98], [278.01, 138.07], [277.46, 143.69]]]}	\N	f	{}	f	\N	2	\N	\N	{}	\N	\N	f	f
 135	{"en": "A2 - Corridor West"}	f	f	{"type": "Polygon", "coordinates": [[[414.02, 190.85], [414.03, 189.37], [411.87, 189.36], [411.81, 195.58], [421.62, 195.58], [421.63, 200.44], [421.91, 200.44], [421.91, 201.15], [426.57, 201.15], [426.56, 190.86], [414.02, 190.85]]]}	\N	f	{}	f	\N	2	\N	\N	{}	\N	\N	f	f
@@ -7125,7 +7164,7 @@ COPY public.site_announcement (id, created, active_until, active, author_id, tex
 --
 
 COPY public.site_siteupdate (id, created) FROM stdin;
-1	2024-09-24 11:23:14.436108+02
+1	2024-09-24 09:23:14.436108+00
 \.
 
 
@@ -7217,21 +7256,21 @@ SELECT pg_catalog.setval('public.django_migrations_id_seq', 201, true);
 -- Name: editor_changedobject_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public.editor_changedobject_id_seq', 22, true);
+SELECT pg_catalog.setval('public.editor_changedobject_id_seq', 28, true);
 
 
 --
 -- Name: editor_changeset_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public.editor_changeset_id_seq', 4, true);
+SELECT pg_catalog.setval('public.editor_changeset_id_seq', 8, true);
 
 
 --
 -- Name: editor_changesetupdate_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public.editor_changesetupdate_id_seq', 10, true);
+SELECT pg_catalog.setval('public.editor_changesetupdate_id_seq', 31, true);
 
 
 --
@@ -7399,14 +7438,14 @@ SELECT pg_catalog.setval('public.mapdata_locationgroupcategory_id_seq', 5, true)
 -- Name: mapdata_locationslug_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public.mapdata_locationslug_id_seq', 151, true);
+SELECT pg_catalog.setval('public.mapdata_locationslug_id_seq', 153, true);
 
 
 --
 -- Name: mapdata_mapupdate_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public.mapdata_mapupdate_id_seq', 1821, true);
+SELECT pg_catalog.setval('public.mapdata_mapupdate_id_seq', 1827, true);
 
 
 --


### PR DESCRIPTION
@clezag 
as per commit message, I did a manual dump from the changes the team performed on the testing environment since I wasn't sure if they would have been persisted otherwise (I see there is a dump script in the repo, but I am unsure if/when/how it is invoked).

This should bring no functional changes to the testing environment as the dump and the database content are equal, but will allow us to deploy to production.